### PR TITLE
BAU: Removed function URL outputs as they are not needed

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -176,27 +176,26 @@ Resources:
         - !Ref AWS::NoValue
 
 Outputs:
-  BearerTokenHandlerFunctionURLEndpoint:
-    Description: FURLFunction function name
-    Value: !GetAtt BearerTokenHandlerFunctionUrl.FunctionUrl
   BearerTokenHandlerFunction:
     Description: "BearerTokenHandler Lambda Function ARN"
     Value: !GetAtt BearerTokenHandlerFunction.Arn
+
   BearerTokenHandlerFunctionIamRole:
     Description: "Implicit IAM Role created for BearerTokenHandler function"
     Value: !GetAtt BearerTokenHandlerFunctionRole.Arn
+
   OAuthTokenStateMachineArn:
     Description: Otg state machine ARN
     Value: !Ref OAuthTokenStateMachine
+
   OAuthTokenStateMachineRole:
     Description: "IAM Role created for OAuth token state machine based on the specified"
     Value: !GetAtt OAuthTokenStateMachineRole.Arn
-  TotpGeneratorFunctionURLEndpoint:
-    Description: FURLFunction function name
-    Value: !GetAtt TotpGeneratorFunctionUrl.FunctionUrl
+
   TotpGeneratorFunction:
     Description: "TotpGenerator Lambda Function ARN"
     Value: !GetAtt TotpGeneratorFunction.Arn
+
   TotpGeneratorFunctionIamRole:
     Description: "Implicit IAM Role created for TotpGenerator function"
     Value: !GetAtt TotpGeneratorFunctionRole.Arn


### PR DESCRIPTION
We are exporting function URLs but these are not needed or used so this has been removed from the `template.yaml`. This is to be consistent with the other HMRC repos. 