### PR TITLE
BAU: Removed FunctionUrlConfig

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -130,7 +130,7 @@
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "7bfab66d307c824a52622af284a0bd486d6525e3",
         "is_verified": false,
-        "line_number": 166
+        "line_number": 158
       }
     ],
     "integration-tests/tests/mocked/oauth-token-generator/MockConfigFile.json": [
@@ -185,5 +185,5 @@
       }
     ]
   },
-  "generated_at": "2023-11-21T17:37:30Z"
+  "generated_at": "2023-11-22T12:01:45Z"
 }

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -102,10 +102,6 @@ Resources:
     Properties:
       CodeUri: ../lambdas/bearer-token-handler
       Handler: bearer-token-handler.lambdaHandler
-      FunctionUrlConfig:
-        AuthType: AWS_IAM
-        Cors:
-          AllowOrigins: ["*"]
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -120,10 +116,6 @@ Resources:
     Properties:
       CodeUri: ../lambdas/totp-generator
       Handler: totp-generator-handler.lambdaHandler
-      FunctionUrlConfig:
-        AuthType: AWS_IAM
-        Cors:
-          AllowOrigins: ["*"]
     Metadata:
       BuildMethod: esbuild
       BuildProperties:


### PR DESCRIPTION
Removed `FunctionUrlConfig` as we do not use them and the account does not have permission to create it. 