### PR TITLE
BAU: Fix subsitution

### DIFF
--- a/step-functions/oauth-token-generator.asl.json
+++ b/step-functions/oauth-token-generator.asl.json
@@ -15,7 +15,7 @@
       "Type": "Task",
       "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
-        "FunctionName": "arn:aws:lambda:eu-west-2:366077495114:function:preview-otg-hmrc-oj-2455-fix-TotpGeneratorFunction-cRx7sNoPB4PM",
+        "FunctionName": "${TotpGeneratorFunctionArn}",
         "Payload": {
           "SecretString.$": "$.totpSecret.SecretString"
         }


### PR DESCRIPTION
## Proposed changes

### What changed
The generate TOTP function was still using the function name from a preview branch. This has been updated.
