### PR TITLE
OJ-2391: use pass state to workaround stack interpolation

### DIFF
--- a/integration-tests/tests/mocked/oauth-token-generator/oauth-token-generator-happy.test.ts
+++ b/integration-tests/tests/mocked/oauth-token-generator/oauth-token-generator-happy.test.ts
@@ -16,7 +16,7 @@ describe("oauth-token-generator-happy.test", () => {
     expect(sfnContainer.getContainer()).toBeDefined();
   });
 
-  xit("should successfully pass a happy path journey", async () => {
+  it("should successfully pass a happy path journey", async () => {
     const input = JSON.stringify({ tokenType: "stub" });
     const responseStepFunction = await sfnContainer.startStepFunctionExecution(
       "Happy",

--- a/integration-tests/tests/mocked/oauth-token-generator/sfn-constants.ts
+++ b/integration-tests/tests/mocked/oauth-token-generator/sfn-constants.ts
@@ -10,10 +10,7 @@ export const StepFunctionConstants = {
   mockFileHostPath: path.join(__dirname, "./MockConfigFile.json"),
   mockFileContainerPath: "/home/stepfunctionslocal/MockConfigFile.json",
   DUMMY_ROLE: "arn:aws:iam::123456789012:role/DummyRole",
-  STATE_MACHINE_ASL: fs
-    .readFileSync(STATE_MACHINE_FILE)
-    .toString()
-    .replaceAll("${StackName}", "STACK_NAME"),
+  STATE_MACHINE_ASL: fs.readFileSync(STATE_MACHINE_FILE).toString(),
   STATE_MACHINE_NAME: "oauth-token-generator",
   AWS_ACCOUNT_ID: "123456789012",
   AWS_DEFAULT_REGION: "local",

--- a/step-functions/oauth-token-generator.asl.json
+++ b/step-functions/oauth-token-generator.asl.json
@@ -4,12 +4,23 @@
   "States": {
     "Fetch TOTP Secret": {
       "Type": "Task",
-      "Next": "Generate TOTP Code",
+      "Next": "Get StackName",
       "Parameters": {
         "SecretId.$": "States.Format('HMRC/TOTPSecret/{}', $.tokenType)"
       },
+      "ResultSelector": {
+        "SecretString.$": "$.SecretString"
+      },
       "Resource": "arn:aws:states:::aws-sdk:secretsmanager:getSecretValue",
       "ResultPath": "$.totpSecret"
+    },
+    "Get StackName": {
+      "Type": "Pass",
+      "Parameters": {
+        "value": "${StackName}"
+      },
+      "Next": "Generate TOTP Code",
+      "ResultPath": "$.StackName"
     },
     "Generate TOTP Code": {
       "Type": "Task",
@@ -61,7 +72,7 @@
       "Type": "Task",
       "Next": "Invoke HMRC OAuth Token API",
       "Parameters": {
-        "Name.$": "States.Format('/${StackName}/HMRC/OAuthURL/{}', $.tokenType)"
+        "Name.$": "States.Format('/{}/HMRC/OAuthURL/{}', $.StackName.value, $.tokenType)"
       },
       "Resource": "arn:aws:states:::aws-sdk:ssm:getParameter",
       "ResultSelector": {
@@ -95,6 +106,9 @@
           "MaxAttempts": 3
         }
       ],
+      "ResultSelector": {
+        "Payload.$": "$.Payload"
+      },
       "Next": "Store Bearer Token",
       "ResultPath": "$.response"
     },
@@ -115,7 +129,7 @@
         "FlexibleTimeWindow": {
           "Mode": "OFF"
         },
-        "Name.$": "States.Format('${StackName}-{}', $.tokenType)",
+        "Name.$": "States.Format('{}-{}', $.StackName.value, $.tokenType)",
         "ScheduleExpression.$": "States.Format('rate({} minutes)', $.response.Payload.tokenExpiryInMinutes)",
         "Target": {
           "Arn.$": "$$.StateMachine.Id",


### PR DESCRIPTION
## Proposed changes

StackName not playing nice with with step function when `States.Format('${StackName}-{}', $.tokenType)`

### What changed

Introduced
An extra state to get the StackName

### Why did it change

Can re-introduce Mock Test
