### PR TITLE
OJ-2391: Made expiry /2

### DIFF
--- a/lambdas/bearer-token-handler/src/bearer-token-handler.ts
+++ b/lambdas/bearer-token-handler/src/bearer-token-handler.ts
@@ -30,11 +30,12 @@ export class BearerTokenHandler implements LambdaInterface {
       });
 
       const body = (await response.json()) as OAuthResponse;
+      const expiry = body.expires_in / 2;
 
       return {
         token: body.access_token,
-        tokenExpiry: (Date.now() + body.expires_in * 1000).toString(),
-        tokenExpiryInMinutes: body.expires_in / 60,
+        tokenExpiry: (Date.now() + expiry * 1000).toString(),
+        tokenExpiryInMinutes: expiry / 60,
       };
     } catch (error: unknown) {
       if (error instanceof Error) {

--- a/lambdas/bearer-token-handler/tests/bearer-token-handler.test.ts
+++ b/lambdas/bearer-token-handler/tests/bearer-token-handler.test.ts
@@ -8,12 +8,15 @@ describe("bearer-token-handler", () => {
   });
 
   it("should return a bearer token with the expected expiry date", async () => {
-    jest.spyOn(Date, "now").mockReturnValue(1622502000000);
+    const mockedExpiryInSeconds = 14400;
+    const mockedAccessToken = 123456789;
+    const firstJune2021Midnight = 1622502000000;
+    jest.spyOn(Date, "now").mockReturnValue(firstJune2021Midnight);
     global.fetch = jest.fn();
     (global.fetch as jest.Mock).mockResolvedValueOnce({
       json: jest.fn().mockResolvedValueOnce({
-        access_token: 12345678,
-        expires_in: 144000,
+        access_token: mockedAccessToken,
+        expires_in: mockedExpiryInSeconds,
       }),
     });
     const bearerTokenHandler = new BearerTokenHandler();
@@ -30,10 +33,16 @@ describe("bearer-token-handler", () => {
       },
     };
     const result = await bearerTokenHandler.handler(event, {} as Context);
+    const halfOfExpiryInSeconds = mockedExpiryInSeconds / 2;
+    const expectedTokenExpiry = (
+      firstJune2021Midnight +
+      halfOfExpiryInSeconds * 1000
+    ).toString();
+    const expectedTokenExpiryInMins = halfOfExpiryInSeconds / 60;
     expect(result).toStrictEqual({
-      token: 12345678,
-      tokenExpiry: "1622574000000",
-      tokenExpiryInMinutes: 1200,
+      token: mockedAccessToken,
+      tokenExpiry: expectedTokenExpiry,
+      tokenExpiryInMinutes: expectedTokenExpiryInMins,
     });
   });
 });

--- a/lambdas/bearer-token-handler/tests/bearer-token-handler.test.ts
+++ b/lambdas/bearer-token-handler/tests/bearer-token-handler.test.ts
@@ -32,8 +32,8 @@ describe("bearer-token-handler", () => {
     const result = await bearerTokenHandler.handler(event, {} as Context);
     expect(result).toStrictEqual({
       token: 12345678,
-      tokenExpiry: "1622646000000",
-      tokenExpiryInMinutes: 144000 / 60,
+      tokenExpiry: "1622574000000",
+      tokenExpiryInMinutes: 1200,
     });
   });
 });


### PR DESCRIPTION
## Proposed changes

### What changed
Made the expiry data half of what HMRC gives us, this is to give us a buffer when attempting to refresh.

### Issue tracking
- [OJ-2391](https://govukverify.atlassian.net/browse/OJ-2391)


[OJ-2391]: https://govukverify.atlassian.net/browse/OJ-2391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ