### PR TITLE
OJ-2492: Integration tests

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -30,3 +30,14 @@ jobs:
     permissions:
       id-token: write
       contents: read
+
+  aws-tests:
+    name: Run tests
+    needs: deploy
+    uses: ./.github/workflows/run-aws-tests.yml
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      stack-name: ${{ needs.deploy.outputs.stack-name }}
+      aws-region: ${{ needs.deploy.outputs.aws-region }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,27 @@
+name: Integration tests
+
+on: workflow_dispatch
+permissions: {}
+
+jobs:
+  deploy:
+    name: Preview
+    uses: ./.github/workflows/deploy-branch.yml
+    permissions:
+      id-token: write
+      contents: read
+
+  aws-tests:
+    name: Integration tests
+    needs: deploy
+    uses: ./.github/workflows/run-aws-tests.yml
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      stack-name: ${{ needs.deploy.outputs.stack-name }}
+      aws-region: ${{ needs.deploy.outputs.aws-region }}
+
+  mocked-tests:
+    name: Integration tests
+    uses: ./.github/workflows/run-mocked-tests.yml

--- a/.github/workflows/run-aws-tests.yml
+++ b/.github/workflows/run-aws-tests.yml
@@ -1,0 +1,48 @@
+name: AWS tests
+
+on:
+  workflow_call:
+    inputs:
+      stack-name: { required: true, type: string }
+      aws-region: { required: false, type: string }
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: aws-tests-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  run-tests:
+    name: AWS
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    environment: development
+    steps:
+      - name: Pull repository
+        uses: actions/checkout@v4
+
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --include-workspace-root
+
+      - name: Assume AWS Role
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.DEPLOYMENT_ROLE_ARN }}
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: Run tests
+        uses: govuk-one-login/github-actions/node/run-script@e6b6ed890b35904e1be79f7f35ffec983fa4d9db
+        env:
+          STACK_NAME: ${{ inputs.stack-name }}
+          AWS_REGION: ${{ inputs.aws-region }}
+        with:
+          working-directory: integration-tests
+          script: npm run test:aws -- --config jest.config.ci.ts

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -470,3 +470,6 @@ Outputs:
   OAuthTokenStateMachineArn:
     Description: OTG state machine ARN
     Value: !Ref OAuthTokenStateMachine
+  BearerTokenRetrievalStateMachineArn:
+    Description: Bearer Token Retrieval state machine ARN
+    Value: !Ref BearerTokenRetrievalStateMachine

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -1,11 +1,16 @@
 {
   "name": "otg-hmrc-api",
   "scripts": {
-    "lint:prettier-fix": "pre-commit run prettier --all-files",
-    "lint:eslint": "eslint ..",
-    "test": "npm run test:mocked --",
-    "test:aws": "npm run test:aws --",
-    "test:mocked": "jest --silent --select-projects integration-tests/mocked"
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "unit:all": "jest --runInBand",
+    "unit:aws": "jest --silent --select-projects integration-tests/aws --runInBand",
+    "unit:mocked": "jest --silent --select-projects integration-tests/mocked",
+    "test:all": "npm run unit:all --",
+    "test:aws": "npm run unit:aws --",
+    "test:mocked": "npm run unit:mocked --",
+    "deploy": "../deploy.sh",
+    "compile": "tsc"
   },
   "dependencies": {},
   "devDependencies": {

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -4,6 +4,7 @@
     "lint:prettier-fix": "pre-commit run prettier --all-files",
     "lint:eslint": "eslint ..",
     "test": "npm run test:mocked --",
+    "test:aws": "npm run test:aws --",
     "test:mocked": "jest --silent --select-projects integration-tests/mocked"
   },
   "dependencies": {},

--- a/integration-tests/tests/aws/bearer-token-retrieval/bearer-token-retrieval.test.ts
+++ b/integration-tests/tests/aws/bearer-token-retrieval/bearer-token-retrieval.test.ts
@@ -23,6 +23,7 @@ describe("bearer-token-retrieval", () => {
     );
     const result = JSON.parse(startExecutionResult.output || "");
     const body = JSON.parse(result.body || "");
+
     expect(result.httpStatus).toBe(200);
     expect(body.token).toBe("goodToken");
     expect(body.expiry).toBeDefined();
@@ -36,6 +37,7 @@ describe("bearer-token-retrieval", () => {
       }
     );
     const result = JSON.parse(startExecutionResult.output || "");
+
     expect(result.httpStatus).toBe(400);
     expect(result.body).toBeUndefined();
   });

--- a/integration-tests/tests/aws/bearer-token-retrieval/bearer-token-retrieval.test.ts
+++ b/integration-tests/tests/aws/bearer-token-retrieval/bearer-token-retrieval.test.ts
@@ -1,0 +1,42 @@
+import { stackOutputs } from "../resources/cloudformation-helper";
+import { executeExpressStepFunction } from "../resources/stepfunction-helper";
+
+jest.setTimeout(60_000);
+
+describe("bearer-token-retrieval", () => {
+  const input = {
+    tokenType: "stub",
+  };
+
+  let output: Partial<{
+    BearerTokenRetrievalStateMachineArn: string;
+  }>;
+
+  beforeEach(async () => {
+    output = await stackOutputs(process.env.STACK_NAME);
+  });
+
+  it("should fetch a bearer token", async () => {
+    const startExecutionResult = await executeExpressStepFunction(
+      output.BearerTokenRetrievalStateMachineArn as string,
+      input
+    );
+    const result = JSON.parse(startExecutionResult.output || "");
+    const body = JSON.parse(result.body || "");
+    expect(result.httpStatus).toBe(200);
+    expect(body.token).toBe("goodToken");
+    expect(body.expiry).toBeDefined();
+  });
+
+  it("should error when tokenType is invalid", async () => {
+    const startExecutionResult = await executeExpressStepFunction(
+      output.BearerTokenRetrievalStateMachineArn as string,
+      {
+        tokenType: "dummy",
+      }
+    );
+    const result = JSON.parse(startExecutionResult.output || "");
+    expect(result.httpStatus).toBe(400);
+    expect(result.body).toBeUndefined();
+  });
+});

--- a/integration-tests/tests/aws/jest.config.ts
+++ b/integration-tests/tests/aws/jest.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from "jest";
+import baseConfig from "../../jest.config";
+
+export default {
+  ...baseConfig,
+  projects: [],
+  displayName: "integration-tests/aws",
+  setupFiles: ["<rootDir>/setEnvVars.js"],
+} satisfies Config;

--- a/integration-tests/tests/aws/resources/aws-helper.ts
+++ b/integration-tests/tests/aws/resources/aws-helper.ts
@@ -1,0 +1,58 @@
+import { ServiceInputTypes, ServiceOutputTypes } from "@aws-sdk/lib-dynamodb";
+import { Command } from "@aws-sdk/types";
+import { Client, SmithyResolvedConfiguration } from "@smithy/smithy-client";
+import { HttpHandlerOptions } from "@smithy/types";
+
+type AWSServiceClient<
+  Input extends ServiceInputTypes,
+  Output extends ServiceOutputTypes,
+> = Client<
+  HttpHandlerOptions,
+  Input,
+  Output,
+  SmithyResolvedConfiguration<HttpHandlerOptions>
+>;
+
+type AWSServiceClientCommand<
+  Input extends ServiceInputTypes,
+  InputType extends Input,
+  Output extends ServiceOutputTypes,
+  OutputType extends Output,
+> = Command<
+  Input,
+  InputType,
+  Output,
+  OutputType,
+  SmithyResolvedConfiguration<HttpHandlerOptions>
+>;
+
+export function createSendCommandWithClient<
+  Input extends ServiceInputTypes,
+  InputType extends Input,
+  Output extends ServiceOutputTypes,
+  OutputType extends Output,
+>(client: AWSServiceClient<Input, Output>) {
+  return function <
+    CommandInputType extends Input = InputType,
+    CommandOutputType extends Output = OutputType,
+  >(
+    commandConstructor: new (
+      input: CommandInputType
+    ) => AWSServiceClientCommand<
+      Input,
+      CommandInputType,
+      Output,
+      CommandOutputType
+    >,
+    commandInput: CommandInputType
+  ) {
+    return client.send(new commandConstructor(commandInput));
+  };
+}
+
+export function createSendCommand<
+  Input extends ServiceInputTypes,
+  Output extends ServiceOutputTypes,
+>(clientConstructor: () => AWSServiceClient<Input, Output>) {
+  return createSendCommandWithClient(clientConstructor());
+}

--- a/integration-tests/tests/aws/resources/cloudformation-helper.ts
+++ b/integration-tests/tests/aws/resources/cloudformation-helper.ts
@@ -1,0 +1,35 @@
+import {
+  CloudFormationClient,
+  DescribeStacksCommand,
+  Output,
+} from "@aws-sdk/client-cloudformation";
+import { createSendCommand } from "./aws-helper";
+
+const sendCommand = createSendCommand(
+  () =>
+    new CloudFormationClient({
+      region: process.env.AWS_REGION,
+    })
+);
+
+export const stackOutputs = async (
+  stackName?: string
+): Promise<{ [key: string]: string }> => {
+  if (!stackName) {
+    throw new Error("Stack name not provided.");
+  }
+
+  const response = await sendCommand(DescribeStacksCommand, {
+    StackName: stackName,
+  });
+
+  const stackOutputs = response?.Stacks?.at(0)?.Outputs ?? [];
+
+  return stackOutputs.reduce(
+    (acc: { [key: string]: string }, output: Output) => {
+      acc[output?.OutputKey as string] = output.OutputValue as string;
+      return acc;
+    },
+    {}
+  );
+};

--- a/integration-tests/tests/aws/resources/stepfunction-helper.ts
+++ b/integration-tests/tests/aws/resources/stepfunction-helper.ts
@@ -1,0 +1,31 @@
+import {
+  SFNClient,
+  StartExecutionCommand,
+  StartSyncExecutionCommand,
+} from "@aws-sdk/client-sfn";
+import { createSendCommand } from "./aws-helper";
+
+const sendCommand = createSendCommand(
+  () =>
+    new SFNClient({
+      region: process.env.AWS_REGION,
+    })
+);
+
+export const executeStepFunction = async (
+  stateMachineArn: string,
+  input: Record<string, unknown> = {}
+) =>
+  sendCommand(StartExecutionCommand, {
+    stateMachineArn,
+    input: JSON.stringify(input),
+  });
+
+export const executeExpressStepFunction = async (
+  stateMachineArn: string,
+  input: Record<string, unknown> = {}
+) =>
+  sendCommand(StartSyncExecutionCommand, {
+    stateMachineArn,
+    input: JSON.stringify(input),
+  });

--- a/integration-tests/tests/aws/setEnvVars.js
+++ b/integration-tests/tests/aws/setEnvVars.js
@@ -1,0 +1,1 @@
+process.env.AWS_REGION = "eu-west-2";


### PR DESCRIPTION
## Proposed changes

### What and Why did it change
* Added infrastructure for AWS integration tests
* Added additional methods to run both express state machines and standard state machines in `stepfunction-helper.ts`
* Added happy and unhappy test for bearer token retrieval state machine
* Added GHA to run the tests

This was added to increase confidence in our code as the mocked tests do not entirely satisfy this. 
