### PR TITLE
BAU: Removed Lambda layer

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -510,8 +510,6 @@ Resources:
         LogGroup: !Sub /aws/lambda/${AWS::StackName}/SecretsManagerHandlerFunction
       CodeSigningConfigArn:
         !If [EnforceCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
-      Layers:
-        - arn:aws:lambda:eu-west-2:133256977650:layer:AWS-Parameters-and-Secrets-Lambda-Extension-Arm64:11
       Policies:
         - Statement:
             - Effect: Allow


### PR DESCRIPTION
## Proposed changes

### What changed
Removed the Lamda layer from the secrets manager handler lambda.

### Why did it change
To use this layer in our build+ accounts we have to deploy the layer into our own accounts. This means downloading the .zip and signing it then creating it as a custom layer in the account. This is currently not being done in our govuk-one-login repos. 

After speaking to SREs/TL we have decided to leave the caching out for now as Secrets Manager supports 10,000 requests per second which will be fine for NINO/KBV. 

I have left the Lambda there so we can introduce caching in the future without having to repeat this work. 