### PR TITLE
BAU: Replaced Lambda call with Get Secret

### DIFF
--- a/step-functions/bearer-token-retrieval.asl.json
+++ b/step-functions/bearer-token-retrieval.asl.json
@@ -4,31 +4,22 @@
   "States": {
     "Fetch Bearer Token": {
       "Type": "Task",
-      "Resource": "arn:aws:states:::lambda:invoke",
-      "Parameters": {
-        "Payload": {
-          "secretName.$": "States.Format('HMRC/BearerToken/{}', $.tokenType)"
-        },
-        "FunctionName": "${SecretsManagerHandlerFunctionArn}"
-      },
-      "Retry": [
-        {
-          "ErrorEquals": ["States.ALL"],
-          "IntervalSeconds": 1,
-          "MaxAttempts": 3,
-          "BackoffRate": 2
-        }
-      ],
       "Next": "Token and Expiry",
-      "ResultSelector": {
-        "secret.$": "States.StringToJson($.Payload.value)"
+      "Parameters": {
+        "SecretId.$": "States.Format('HMRC/BearerToken/{}', $.tokenType)"
       },
+      "Resource": "arn:aws:states:::aws-sdk:secretsmanager:getSecretValue",
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Next": "Generate Fail Response"
         }
-      ]
+      ],
+      "ResultSelector": {
+        "secret.$": "States.StringToJson($.SecretString)"
+      }
     },
     "Generate Fail Response": {
       "Type": "Pass",


### PR DESCRIPTION
Removed the Secrets Manager Handler Lambda call and put back the Get Secret state. This is because we are no longer using the Lambda for caching as described: https://github.com/govuk-one-login/ipv-cri-otg-hmrc/pull/61