### PR TITLE
IPS-667 OTG Monitoring and alerting for event bridge

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -67,6 +67,23 @@ Mappings:
     production:
       CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
 
+  SchedulerConfig:
+    dev:
+      NumRetries: 3
+      RetryDelaySeconds: 600
+    build:
+      NumRetries: 185
+      RetryDelaySeconds: 600
+    staging:
+      NumRetries: 186
+      RetryDelaySeconds: 600
+    integration:
+      NumRetries: 185
+      RetryDelaySeconds: 600
+    production:
+      NumRetries: 185
+      RetryDelaySeconds: 86400
+
 Globals:
   Function:
     Timeout: 30
@@ -129,8 +146,8 @@ Resources:
     Type: AWS::Scheduler::Schedule
     Condition: IsNotProdEnvironment
     Properties:
-      Name: !Sub ${AWS::StackName}-sandbox
-      Description: OTG refresh schedule for the sandbox token
+      Name: !Sub "${AWS::StackName}-sandbox"
+      Description: "OTG refresh schedule for the sandbox token"
       FlexibleTimeWindow:
         Mode: "OFF"
       ScheduleExpression: rate(10 minutes)
@@ -139,16 +156,58 @@ Resources:
         Arn: !Ref OAuthTokenStateMachine
         Input: '{ "tokenType": "sandbox" }'
         RetryPolicy:
-          MaximumEventAgeInSeconds: 86400
-          MaximumRetryAttempts: 185
+          MaximumEventAgeInSeconds:  !FindInMap [ SchedulerConfig, !Ref Environment, RetryDelaySeconds ]
+          MaximumRetryAttempts: !FindInMap [ SchedulerConfig, !Ref Environment, NumRetries ]
         RoleArn: !GetAtt RefreshSchedulerRole.Arn
+        DeadLetterConfig:
+          Arn:
+            Fn::GetAtt:
+              - SandboxTokenDeadLetterQueue
+              - Arn
+
+  SandboxTokenDeadLetterQueue:
+    Type: AWS::SQS::Queue
+    Condition: IsNotProdEnvironment
+    Properties:
+      ContentBasedDeduplication: False
+      FifoQueue: False
+      MessageRetentionPeriod: 1800
+      QueueName: !Sub "${AWS::StackName}-sandbox-dlq"
+      ReceiveMessageWaitTimeSeconds: 20
+      SqsManagedSseEnabled: False
+      VisibilityTimeout: 60
+
+  SandboxTokenRefreshSchedulerAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsNotProdEnvironment
+    Properties:
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: "Alarm if token refresh queue grows beyond 0 messages"
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: QueueName
+          Value:
+            Fn::GetAtt:
+              - SandboxTokenDeadLetterQueue
+              - QueueName
+      EvaluationPeriods: '1'
+      InsufficientDataActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      MetricName: ApproximateNumberOfMessagesVisible
+      Namespace: AWS/SQS
+      Period: '300'
+      Statistic: Sum
+      Threshold: '0'
 
   ProductionTokenRefreshScheduler:
     Type: AWS::Scheduler::Schedule
     Condition: IsProdEnvironment
     Properties:
-      Name: !Sub ${AWS::StackName}-production
-      Description: OTG refresh schedule for the production token
+      Name: !Sub "${AWS::StackName}-production"
+      Description: "OTG refresh schedule for the production token"
       FlexibleTimeWindow:
         Mode: "OFF"
       ScheduleExpression: rate(10 minutes)
@@ -157,9 +216,51 @@ Resources:
         Arn: !Ref OAuthTokenStateMachine
         Input: '{ "tokenType": "production" }'
         RetryPolicy:
-          MaximumEventAgeInSeconds: 86400
-          MaximumRetryAttempts: 185
+          MaximumEventAgeInSeconds: !FindInMap [ SchedulerConfig, !Ref Environment, RetryDelaySeconds ]
+          MaximumRetryAttempts: !FindInMap [ SchedulerConfig, !Ref Environment, NumRetries ]
         RoleArn: !GetAtt RefreshSchedulerRole.Arn
+        DeadLetterConfig:
+          Arn:
+            Fn::GetAtt:
+              - ProductionTokenDeadLetterQueue
+              - Arn
+
+  ProductionTokenDeadLetterQueue:
+    Type: AWS::SQS::Queue
+    Condition: IsProdEnvironment
+    Properties:
+      ContentBasedDeduplication: False
+      FifoQueue: False
+      MessageRetentionPeriod: 1800
+      QueueName: !Sub "${AWS::StackName}-production-dlq"
+      ReceiveMessageWaitTimeSeconds: 20
+      SqsManagedSseEnabled: False
+      VisibilityTimeout: 60
+
+  ProductionTokenRefreshSchedulerAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProdEnvironment
+    Properties:
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: "Alarm if token refresh queue grows beyond 0 messages"
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: QueueName
+          Value:
+            Fn::GetAtt:
+              - ProductionTokenDeadLetterQueue
+              - QueueName
+      EvaluationPeriods: '1'
+      InsufficientDataActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      MetricName: ApproximateNumberOfMessagesVisible
+      Namespace: AWS/SQS
+      Period: '300'
+      Statistic: Sum
+      Threshold: '0'
 
   RefreshSchedulerRole:
     Type: AWS::IAM::Role

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -165,10 +165,46 @@ Resources:
               - SandboxTokenDeadLetterQueue
               - Arn
 
+  SandboxTokenDeadLetterQueueEncryptionKey:
+    Type: AWS::KMS::Key
+    Condition: IsNotProdEnvironment
+    Properties:
+      Description: "Symmetric key used to encrypt audit messages at rest in SQS"
+      EnableKeyRotation: true
+      KeySpec: SYMMETRIC_DEFAULT
+      KeyPolicy:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: 'Enable Root access'
+            Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action:
+              - 'kms:*'
+            Resource: '*'
+      Tags:
+        - Key: Name
+          Value: !Join
+              - "-"
+              - - !Ref AWS::StackName
+                - "sandboxTokenDeadLetterQueueEncryptionKey"
+        - Key: "awsStackName"
+          Value: !Sub "${AWS::StackName}"
+        - Key: Source
+          Value: "govuk-one-login/ipv-cri-otg-hmrc/infrastructure/template.yaml"
+
+  SandboxTokenDeadLetterQueueEncryptionKeyAlias:
+    Type: AWS::KMS::Alias
+    Condition: IsNotProdEnvironment
+    Properties:
+      AliasName: !Sub alias/${AWS::StackName}/sandboxTokenDeadLetterQueueEncryptionKey
+      TargetKeyId: !Ref SandboxTokenDeadLetterQueueEncryptionKey
+
   SandboxTokenDeadLetterQueue:
     Type: AWS::SQS::Queue
     Condition: IsNotProdEnvironment
     Properties:
+      KmsMasterKeyId: !Ref SandboxTokenDeadLetterQueueEncryptionKeyAlias
       MessageRetentionPeriod: 1800
       QueueName: !Sub "${AWS::StackName}-sandbox-dlq"
       ReceiveMessageWaitTimeSeconds: 20
@@ -223,10 +259,47 @@ Resources:
               - ProductionTokenDeadLetterQueue
               - Arn
 
+  ProductionTokenDeadLetterQueueEncryptionKey:
+    Type: AWS::KMS::Key
+    Condition: IsProdEnvironment
+    Properties:
+      Description: "Symmetric key used to encrypt audit messages at rest in SQS"
+      EnableKeyRotation: true
+      KeySpec: SYMMETRIC_DEFAULT
+      KeyPolicy:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: 'Enable Root access'
+            Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action:
+              - 'kms:*'
+            Resource: '*'
+      Tags:
+        - Key: Name
+          Value: !Join
+              - "-"
+              - - !Ref AWS::StackName
+                - "productionTokenDeadLetterQueueEncryptionKey"
+        - Key: "awsStackName"
+          Value: !Sub "${AWS::StackName}"
+        - Key: Source
+          Value: "govuk-one-login/ipv-cri-otg-hmrc/infrastructure/template.yaml"
+
+  ProductionTokenDeadLetterQueueEncryptionKeyAlias:
+    Type: AWS::KMS::Alias
+    Condition: IsProdEnvironment
+    Properties:
+      AliasName: !Sub alias/${AWS::StackName}/productionTokenDeadLetterQueueEncryptionKey
+      TargetKeyId: !Ref ProductionTokenDeadLetterQueueEncryptionKey
+
+
   ProductionTokenDeadLetterQueue:
     Type: AWS::SQS::Queue
     Condition: IsProdEnvironment
     Properties:
+      KmsMasterKeyId: !Ref ProductionTokenDeadLetterQueueEncryptionKeyAlias
       MessageRetentionPeriod: 1800
       QueueName: !Sub "${AWS::StackName}-production-dlq"
       ReceiveMessageWaitTimeSeconds: 20

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -169,7 +169,6 @@ Resources:
     Type: AWS::SQS::Queue
     Condition: IsNotProdEnvironment
     Properties:
-      FifoQueue: False
       MessageRetentionPeriod: 1800
       QueueName: !Sub "${AWS::StackName}-sandbox-dlq"
       ReceiveMessageWaitTimeSeconds: 20
@@ -228,7 +227,6 @@ Resources:
     Type: AWS::SQS::Queue
     Condition: IsProdEnvironment
     Properties:
-      FifoQueue: False
       MessageRetentionPeriod: 1800
       QueueName: !Sub "${AWS::StackName}-production-dlq"
       ReceiveMessageWaitTimeSeconds: 20

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -169,7 +169,6 @@ Resources:
     Type: AWS::SQS::Queue
     Condition: IsNotProdEnvironment
     Properties:
-      ContentBasedDeduplication: False
       FifoQueue: False
       MessageRetentionPeriod: 1800
       QueueName: !Sub "${AWS::StackName}-sandbox-dlq"
@@ -229,7 +228,6 @@ Resources:
     Type: AWS::SQS::Queue
     Condition: IsProdEnvironment
     Properties:
-      ContentBasedDeduplication: False
       FifoQueue: False
       MessageRetentionPeriod: 1800
       QueueName: !Sub "${AWS::StackName}-production-dlq"


### PR DESCRIPTION
## Proposed changes

### What changed

* Added dead letter queues for event bridge schedules (not stubs)
* Added cloudwatch alarms for the dead letter queues if message count is greater than zero 
* Added map for retries and delays.

### Why did it change

To enable monitoring and alerting on the HMRC OTG token refresh

### Issue tracking

- [IPS-667](https://govukverify.atlassian.net/browse/IPS-667)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed



[IPS-667]: https://govukverify.atlassian.net/browse/IPS-667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ