### PR TITLE
FIX: Correctly delete stacks for closed PRs

### DIFF
--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           usage: Stack name
           prefix: preview-otg-hmrc
-          length-limit: 128
+          length-limit: 43
           verbose: false
 
       - name: Delete stack

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -865,18 +865,18 @@ Resources:
           MetricNamespace: !Sub "${AWS::StackName}/LogMessages"
 
   BearerTokenRetrievalStateMachineAlarm:
-    Type: "AWS::CloudWatch::Alarm"
+    Type: AWS::CloudWatch::Alarm
     Properties:
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
-      AlarmDescription: "Bearer Token failed 4 or more requests in the last hour"
-      AlarmName: !Sub "${AWS::StackName}-${Environment}-BearerTokenRetrievalStateMachineAlarm"
+      AlarmDescription: Bearer Token failed 4 or more requests in the last hour
+      AlarmName: !Sub ${AWS::StackName}-${Environment}-BearerTokenRetrievalStateMachineAlarm
       ComparisonOperator: GreaterThanThreshold
       DatapointsToAlarm: 4
       EvaluationPeriods: 12
-      MetricName: "ExecutionsFailed"
+      MetricName: ExecutionsFailed
       Namespace: AWS/States
       Period: 300
       Statistic: Sum


### PR DESCRIPTION
This was missed in #70:
  - Use the stack name length limit when deleting stacks for closed PRs
  - Apply consistent formatting to the template

