### PR TITLE
Add an Error Alarm for the BearerTokenHandlerFunction

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -482,6 +482,40 @@ Resources:
       DestinationArn: !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
 
   # BearerTokenHandlerFunction Alarms
+  BearerTokenHandlerFunctionErrorMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref BearerTokenHandlerFunctionLogGroup
+      FilterPattern: '{ $.level = "ERROR" }'
+      MetricTransformations:
+        - MetricValue: "1"
+          MetricNamespace: !Sub ${AWS::StackName}/LogMessages
+          MetricName: BearerTokenHandlerFunction-Error
+
+  BearerTokenHandlerFunctionErrorAlarm:
+    DependsOn: BearerTokenHandlerFunctionErrorMetricFilter
+    Type: AWS::CloudWatch::Alarm
+    Condition: DeployAlarms
+    Properties:
+      AlarmName: !Sub ${AWS::StackName}-${Environment}-BearerTokenHandlerFunction-ErrorAlarm
+      AlarmDescription: !Sub Trigger an alarm when Errors occurs. ${SupportManualURL}
+      ActionsEnabled: true
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      InsufficientDataActions: []
+      MetricName: BearerTokenHandlerFunction-Error
+      Namespace: !Sub ${AWS::StackName}/LogMessages
+      Statistic: Sum
+      Dimensions: []
+      Period: 120
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 3
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
   BearerTokenHandlerFunctionFatalErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->
Added a new alarm to the BearerTokenHandlerFunction that is triggered when the Lambda logs errors. 

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
The current fatal error alarms filter does not pick up error logs from the lambda and was not triggering on errors being thrown. 

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2570](https://govukverify.atlassian.net/browse/OJ-2570)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-2570]: https://govukverify.atlassian.net/browse/OJ-2570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ