### PR TITLE
OJ-2587: Configure sandbox environment in OTG integration

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -34,7 +34,9 @@ Conditions:
   IsDevEnvironment: !Equals [!Ref Environment, dev]
   IsLocalDevEnvironment: !Equals [!Ref Environment, localdev]
   IsDevLikeEnvironment: !Or [!Condition IsLocalDevEnvironment, !Condition IsDevEnvironment]
+  IsProdOrIntegrationEnvironment: !Or [!Condition IsProdEnvironment, !Equals [!Ref Environment, integration]]
   IsProdEnvironment: !Equals [!Ref Environment, production]
+  IsNotProdOrIntegrationEnvironment: !Not [!Condition IsProdOrIntegrationEnvironment]
   IsNotDevLikeEnvironment: !Not [!Condition IsDevLikeEnvironment]
   IsNotProdEnvironment: !Not [!Condition IsProdEnvironment]
   DeployAlarms: !Or [!Condition IsProdEnvironment, !Equals [!Ref DeployAlarmsInDev, true]]
@@ -119,7 +121,7 @@ Globals:
 Resources:
   StubTokenRefreshScheduler:
     Type: AWS::Scheduler::Schedule
-    Condition: IsNotProdEnvironment
+    Condition: IsNotProdOrIntegrationEnvironment
     Properties:
       Name: !Sub ${AWS::StackName}-stub
       Description: OTG refresh schedule for the stub token
@@ -329,7 +331,7 @@ Resources:
 
   StubOAuthUrlParameter:
     Type: AWS::SSM::Parameter
-    Condition: IsNotProdEnvironment
+    Condition: IsNotProdOrIntegrationEnvironment
     Properties:
       Name: !Sub /${AWS::StackName}/HMRC/OAuthURL/stub
       Type: String


### PR DESCRIPTION

## Proposed changes

### What changed

Created `IsProdOrIntegrationEnvironment` and `IsNotProdOrIntegrationEnvironment` conditions to prevent imposter url referencing in integration environment 
ClickOps BearerToken and TOTP parameters in OTG integration environment 
ClickOps ClientId and ClientSecret OTG integration environment

 ClickOps NiNoCheckUrl in Nino Check integration environment

### Why did it change

To configure tokenType for use with HMRC sandbox environment in hmrc-check integration account

### Issue tracking

- [OJ-2587](https://govukverify.atlassian.net/browse/OJ-2587)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-2587]: https://govukverify.atlassian.net/browse/OJ-2587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ