### PR TITLE
OJ-2610: Escape JavaScript in VTL

### DIFF
--- a/infrastructure/private-api.yaml
+++ b/infrastructure/private-api.yaml
@@ -29,7 +29,7 @@ paths:
           application/json:
             Fn::Sub: |-
               {
-                "input": "{\"tokenType\": \"$input.params('tokenType').trim()\"}",
+                "input": "{\"tokenType\": \"$util.escapeJavaScript($input.params('tokenType').trim())\"}",
                 "stateMachineArn": "${BearerTokenRetrievalStateMachine.Arn}"
               }
         responses:

--- a/integration-tests/tests/aws/bearer-token-retrieval/bearer-token-retrieval.test.ts
+++ b/integration-tests/tests/aws/bearer-token-retrieval/bearer-token-retrieval.test.ts
@@ -41,4 +41,17 @@ describe("bearer-token-retrieval", () => {
     expect(result.httpStatus).toBe(400);
     expect(result.body).toBeUndefined();
   });
+
+  it("should error when tokenType is JavaScript", async () => {
+    const startExecutionResult = await executeExpressStepFunction(
+      output.BearerTokenRetrievalStateMachineArn as string,
+      {
+        tokenType: `<script>alert('Attack!');</script>`,
+      }
+    );
+    const result = JSON.parse(startExecutionResult.output || "");
+
+    expect(result.httpStatus).toBe(400);
+    expect(result.body).toBeUndefined();
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -869,8 +869,7 @@
         "@aws-lambda-powertools/parameters": "^2.0.3",
         "@aws-sdk/client-secrets-manager": "^3.549.0",
         "aws-sdk-client-mock": "^4.0.0"
-      },
-      "devDependencies": {}
+      }
     },
     "lambdas/totp-generator": {
       "dependencies": {


### PR DESCRIPTION
## Proposed changes

### What changed and why
Added `$util.escapeJavaScript` to all the bits that in OpenAPI spec that come from user input.

https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html

### Issue tracking
- [OJ-2610](https://govukverify.atlassian.net/browse/OJ-2610)

[OJ-2610]: https://govukverify.atlassian.net/browse/OJ-2610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ