### PR TITLE
OJ-2657: Restrict private API resource policy

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,30 +1,38 @@
 #!/usr/bin/env bash
-cd "$(dirname "${BASH_SOURCE[0]}")"
+cd "$(dirname "${BASH_SOURCE[0]}")/infrastructure"
 set -eu
 
-template=infrastructure/template.yaml
-stack_name="${1:-}"
+stack_name=${1:-${STACK_NAME:-}}
 
-if ! [[ "$stack_name" ]]; then
-  [[ $(aws sts get-caller-identity --query Arn --output text) =~ \/([^\/\.]+)\. ]] && user="${BASH_REMATCH[1]}" || exit
+if ! [[ $stack_name ]]; then
+  [[ $(aws sts get-caller-identity --query Arn --output text) =~ \/([^\/\.]+)\. ]] && user=${BASH_REMATCH[1]} || exit
   stack_name="$user-otg-hmrc"
   echo "» Using stack name '$stack_name'"
 fi
 
-sam validate --template $template
-sam validate --template $template --lint
+export AWS_DEFAULT_REGION=${AWS_REGION:-eu-west-2}
 
-sam build --template $template --cached --parallel
+sam validate -t template.yaml
+sam validate -t template.yaml --lint
+
+sam build -t template.yaml --cached --parallel
+
+if status=$(aws cloudformation describe-stacks --stack-name "$stack_name" \
+  --query "Stacks[0].StackStatus" --output text 2> /dev/null) && [[ $status =~ _FAILED ]]; then
+  echo "» Deleting stack $stack_name in a failed state"
+  sam delete --no-prompts --stack-name "$stack_name"
+fi
 
 sam deploy --stack-name "$stack_name" \
   --no-fail-on-empty-changeset \
   --no-confirm-changeset \
   --resolve-s3 \
   --s3-prefix "$stack_name" \
-  --region "${AWS_REGION:-eu-west-2}" \
   --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
   --tags \
   cri:component=ipv-cri-otg-hmrc \
-  cri:stack-type=localdev \
+  cri:stack-type=dev \
   cri:application=Orange \
-  cri:deployment-source=manual
+  cri:deployment-source=manual \
+  --parameter-overrides \
+  Environment=dev

--- a/infrastructure/samconfig.toml
+++ b/infrastructure/samconfig.toml
@@ -1,14 +1,26 @@
 version = 0.1
+
+[default.build.parameters]
+cached = true
+parallel = true
+
 [default.deploy.parameters]
-stack_name = "otg-hmrc"
-resolve_s3 = true
-s3_prefix = "otg-hmrc"
-region = "eu-west-2"
+stack_name = "<your-name>-otg-hmrc"
+
 capabilities = ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM"]
-image_repositories = []
-disable_rollback = true
+fail_on_empty_changeset = false
+confirm_changeset = false
+s3_prefix = "localdev"
+region = "eu-west-2"
+resolve_s3 = true
+
+tags = [
+    "cri:component=ipv-cri-otg-hmrc",
+    "cri:deployment-source=manual",
+    "cri:application=Orange",
+    "cri:stack-type=dev",
+]
+
 parameter_overrides = [
     "Environment=dev",
-    "CommonStackName=common-cri-api",
-    "CodeSigningEnabled=false"
 ]

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -12,7 +12,7 @@ Parameters:
   Environment:
     Type: String
     Default: dev
-    AllowedValues: [dev, build, staging, integration, production]
+    AllowedValues: [localdev, dev, build, staging, integration, production]
   CodeSigningConfigArn:
     Type: String
     Default: ""
@@ -23,6 +23,13 @@ Parameters:
     Description: Set to the string value `true` to deploy alarms in a DEV environment
     Type: String
     Default: "true"
+  VpcStackName:
+    Type: String
+    Default: otg-vpc
+  AllowedVpcEndpointIds:
+    Type: AWS::SSM::Parameter::Value<String>
+    Description: The SSM parameter containing the list of VPC endpoints allowed to invoke the private API
+    Default: /otg-hmrc/config/AllowedVPCEndpointIDs
   SupportManualURL:
     Description: Link to the OTG support manual
     Type: String
@@ -89,10 +96,10 @@ Globals:
       !If [UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue]
     VpcConfig:
       SecurityGroupIds:
-        - !ImportValue otg-vpc-AWSServicesEndpointSecurityGroupId
+        - Fn::ImportValue: !Sub ${VpcStackName}-AWSServicesEndpointSecurityGroupId
       SubnetIds:
-        - !ImportValue otg-vpc-ProtectedSubnetIdA
-        - !ImportValue otg-vpc-ProtectedSubnetIdB
+        - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
+        - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
     Layers:
       - !Sub
         - "{{resolve:secretsmanager:${SecretArn}:SecretString:NODEJS_LAYER}}"
@@ -405,9 +412,20 @@ Resources:
           - !Ref AWS::NoValue
           - CustomStatements:
               - Effect: Allow
-                Resource: execute-api:/*
                 Action: execute-api:Invoke
+                Resource: execute-api:/*
                 Principal: "*"
+                Condition:
+                  StringEquals:
+                    aws:SourceVpce: !Split
+                      - ","
+                      - !Join
+                        - ","
+                        - - !Ref AllowedVpcEndpointIds
+                          - !If
+                            - IsNotProdOrIntegrationEnvironment
+                            - Fn::ImportValue: !Sub ${VpcStackName}-ExecuteApiGatewayEndpointId
+                            - !Ref AWS::NoValue
 
   PrivateOTGApiAccessLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
OJ-2567: Allow Check HMRC to invoke OTG private API

Add a list of allowed VPC endpoints to the API resource policy:
- Fetch the list of allowed VPC endpoints from the SSM param in all environment
- Additionally, in build, dev and staging allow the OTG's own VPC so that the smoke tests can invoke the API
- Join the list from the SSM with the import of the OTG's VPC endpoint using !Split and !Join functions

---

Improve deploy script
- Get stack name from the environment
- Delete the stack before deployment if it is in a failed state
- Build in the infrastructure directory
- Set the AWS region environment variable used by SAM CLI
- Synchronise samconfig.toml with the dev deployment script
  Set the same flags, values and parameters as the script