### PR TITLE
OJ-2617: Add TotpGeneratorFunctionErrorAlarm 

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -622,6 +622,40 @@ Resources:
       DestinationArn: !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
 
   # TotpGeneratorFunction Alarms
+  TotpGeneratorFunctionErrorMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref TotpGeneratorFunctionLogGroup
+      FilterPattern: '{ $.level = "ERROR" }'
+      MetricTransformations:
+        - MetricValue: "1"
+          MetricNamespace: !Sub ${AWS::StackName}/LogMessages
+          MetricName: TotpGeneratorFunction-Error
+
+  TotpGeneratorFunctionErrorAlarm:
+    DependsOn: TotpGeneratorFunctionErrorMetricFilter
+    Type: AWS::CloudWatch::Alarm
+    Condition: DeployAlarms
+    Properties:
+      AlarmName: !Sub ${AWS::StackName}-${Environment}-TotpGeneratorFunction-ErrorAlarm
+      AlarmDescription: !Sub Trigger an alarm when Error occurs. ${SupportManualURL}
+      ActionsEnabled: true
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      InsufficientDataActions: []
+      MetricName: TotpGeneratorFunction-Error
+      Namespace: !Sub ${AWS::StackName}/LogMessages
+      Statistic: Sum
+      Dimensions: []
+      Period: 120
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 3
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
   TotpGeneratorFunctionFatalErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->
Added a new alarm to the TotpGeneratorFunctionErrorAlarm that is triggered when the Lambda logs errors.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
The current fatal error alarms filter does not pick up 'normal' error logs from the lambda and was not triggering on errors being thrown.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2617](https://govukverify.atlassian.net/browse/OJ-2617)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-2617]: https://govukverify.atlassian.net/browse/OJ-2617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ