### PR TITLE
BAU: Fix redaction when message is not JSON

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -1,0 +1,2 @@
+ignore_checks:
+  - E3020

--- a/lambdas/log-redaction/src/redact-handler.ts
+++ b/lambdas/log-redaction/src/redact-handler.ts
@@ -58,7 +58,7 @@ export class RedactHandler implements LambdaInterface {
             logStreamName: logStream,
             logEvents: logEvents.logEvents.map((event) => ({
               id: event.id,
-              message: JSON.stringify(JSON.parse(event.message), null, 2),
+              message: this.formatMessage(event.message),
               timestamp: event.timestamp,
               extractedFields: event.extractedFields,
             })),
@@ -77,6 +77,14 @@ export class RedactHandler implements LambdaInterface {
       const message = error instanceof Error ? error.message : String(error);
       logger.error(`Error in RedactHandler: ${message}`);
       throw error;
+    }
+  }
+
+  private formatMessage(message: string) {
+    try {
+      return JSON.stringify(JSON.parse(message), null, 2);
+    } catch (error) {
+      return message;
     }
   }
 }


### PR DESCRIPTION
## Proposed changes

### What changed
The redactor now sends the original message if it was not JSON.

### Why did it change
Some messages such as errors are not JSON strings. As such, an exception `SyntaxError: Unexpected number in JSON at position ` was occurring.

Sample error: 

```
2024-08-23T09:41:35.769Z\t8465d4d8-327b-4cc4-857a-f023371aef95\tERROR\tInvoke Error \t{\"errorType\":\"Error\",\"errorMessage\":\"Error response received from HMRC 400 Bad Request\",\"stack\":[\"Error: Error response received from HMRC 400 Bad Request\",\"    at me.handler (/tmp/tmps_yb_f7o/lambdas/bearer-token-handler/src/bearer-token-handler.ts:42:13)\",\"    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\"]}\n to 2024-08-23T09:41:35.769Z\t8465d4d8-327b-4cc4-857a-f023371aef95\tERROR\tInvoke Error \t{\"errorType\":\"Error\",\"errorMessage\":\"Error response received from HMRC 400 Bad Request\",\"stack\":[\"Error: Error response received from HMRC 400 Bad Request\",\"    at me.handler (/tmp/tmps_yb_f7o/lambdas/bearer-token-handler/src/bearer-token-handler.ts:42:13)\",\"    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\"]}\n
```
