### PR TITLE
BAU: Updated error message to include error body

### DIFF
--- a/lambdas/bearer-token-handler/src/bearer-token-handler.ts
+++ b/lambdas/bearer-token-handler/src/bearer-token-handler.ts
@@ -39,8 +39,15 @@ export class BearerTokenHandler implements LambdaInterface {
         };
       }
 
+      let responseBody;
+      try {
+        responseBody = JSON.stringify(await response.json());
+      } catch (ignored) {
+        /* empty */
+      }
+
       throw new Error(
-        `Error response received from HMRC ${response.status} ${response.statusText}`
+        `Error response received from HMRC ${response.status} ${response.statusText}: ${responseBody}`
       );
     } catch (error: unknown) {
       if (error instanceof Error) {


### PR DESCRIPTION
Updated error message to include error body. This was added because when an error occurs with the HMRC API we could not see the error body to identify the problem. 