### PR TITLE
BAU: Change TreatMissingData for alarm

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -902,7 +902,7 @@ Resources:
       Period: 300
       Statistic: Sum
       Threshold: 0
-      TreatMissingData: missing
+      TreatMissingData: notBreaching
       Dimensions:
         - Name: StateMachineArn
           Value: !Ref OAuthTokenStateMachine
@@ -977,7 +977,7 @@ Resources:
       Period: 300
       Statistic: Sum
       Threshold: 0
-      TreatMissingData: missing
+      TreatMissingData: notBreaching
       Dimensions:
         - Name: StateMachineArn
           Value: !Ref BearerTokenRetrievalStateMachine


### PR DESCRIPTION
### What changed

- Change how missing data is treated for cloudwatch alarm

### Why did it change

- The state machine runs every 2 hours
- The alarm was set to monitor if there were more than 4 failed executions in the last hour
- The alarm was status was switching between INSUFFICIENT_DATA and OK between executions, leading to regular, redundant slack notifications for OKActions:

dev: 
<img width="1294" alt="image" src="https://github.com/user-attachments/assets/194a2160-4c51-45b3-8fce-ed379e43e1d9">

staging:
<img width="1322" alt="image" src="https://github.com/user-attachments/assets/ee0e6bf1-79dd-4d4a-be64-d363e1673d88">

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-651](https://govukverify.atlassian.net/browse/IPS-651)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-651]: https://govukverify.atlassian.net/browse/IPS-651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ