### PR TITLE
IPS-665: Create policy for control tower

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -979,6 +979,24 @@ Resources:
                   - !GetAtt OAuthTokenStateMachineRole.Arn
                   - !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/eu-west-2/AWSReservedSSO_di-ipv-cri-otg-hmrc-prod-adm-kms_c1de3f0ff8700ff0"
 
+  DenySecretsIAMPolicy:
+    #Condition: IsProdEnvironment #commented out for testing in dev
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Deny
+            Action:
+              - "states:GetExecutionHistory"
+            Resource:
+              - !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:execution:${AWS::StackName}-OAuthTokenGenerator*
+          - Effect: Deny
+            Action:
+              - "logs:*"
+            Resource:
+              - !GetAtt OAuthTokenStateMachineLogGroup.Arn
+
   OAuthTokenStateMachine:
     Type: AWS::Serverless::StateMachine
     Properties:

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -980,7 +980,7 @@ Resources:
                   - !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/eu-west-2/AWSReservedSSO_di-ipv-cri-otg-hmrc-prod-adm-kms_c1de3f0ff8700ff0"
 
   DenySecretsIAMPolicy:
-    #Condition: IsProdEnvironment #commented out for testing in dev
+    Condition: IsProdEnvironment
     Type: AWS::IAM::ManagedPolicy
     Properties:
       PolicyDocument:


### PR DESCRIPTION
### What changed

- Created IAM policy to deny access to:
  - `OAuthTokenStateMachineLogGroup`
  - State machine execution history of the `OAuthTokenStateMachine` 

### Why did it change

- The TOTP secret is printed in both resources above, and access needs to be limited
- The process for this is for the Dev or SRE team to create the policy, and control tower to attach to the groups, see https://govukverify.atlassian.net/browse/PSREGOV-1242
- The resource policies mentioned in the above ticket already exist in this template

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-665](https://govukverify.atlassian.net/browse/IPS-665)
<img width="1539" alt="Screenshot 2024-09-23 at 11 12 09" src="https://github.com/user-attachments/assets/7ea3af59-d433-4ad5-ae0f-48aad5648435">
<img width="1332" alt="Screenshot 2024-09-23 at 11 13 00" src="https://github.com/user-attachments/assets/387da1c0-fccc-424e-b489-f8fc0fcde4da"> 

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-665]: https://govukverify.atlassian.net/browse/IPS-665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ