### PR TITLE
IPS-1094: Canary deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
 # di-ipv-cri-otg-hmrc
 
 OAuth Token Generator for use with HMRC APIs
+
+## Canaries
+When deploying using sam deploy, canary deployment strategy will be used which is set in LambdaDeploymentPreference and StepFunctionsDeploymentPreference in template.yaml file.
+
+When deploying using the pipeline, canary deployment strategy set in the pipeline will be used and override the default set in template.yaml.
+
+Canary deployments will cause a rollback if any canary alarms associated with a lambda or step-functions are triggered and a slack notification will be sent to #di-orange-warnings-non-prod or #di-orange-warning-alerts-prod.
+
+To skip canaries such as when releasing urgent changes to production, set the last commit message to contain either of these phrases: [skip canary], [canary skip], or [no canary] as specified in the [Canary Escape Hatch guide](https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3836051600/Rollback+Recovery+Guidance#Escape-Hatch%3A-how-to-skip-canary-deployments-when-needed).
+`git commit -m "some message [skip canary]"`
+
+Note: To update LambdaDeploymentPreference or StepFunctionsDeploymentPreference, update the LambdaCanaryDeployment or StepFunctionsDeploymentPreference pipeline parameter in the [identity-common-infra repository](https://github.com/govuk-one-login/identity-common-infra/tree/main/terraform/orange/hmrc-otg). To update the LambdaDeploymentPreference or StepFunctionsDeploymentPreference for a stack in dev using sam deploy, parameter override needs to be set in the [deploy script](./deploy.sh):
+
+`--parameter-overrides LambdaDeploymentPreference=<define-strategy> \`
+`--parameter-overrides StepFunctionsDeploymentPreference=<define-strategy> \`

--- a/infrastructure/private-api.yaml
+++ b/infrastructure/private-api.yaml
@@ -30,7 +30,7 @@ paths:
             Fn::Sub: |-
               {
                 "input": "{\"tokenType\": \"$util.escapeJavaScript($input.params('tokenType').trim())\"}",
-                "stateMachineArn": "${BearerTokenRetrievalStateMachine.Arn}"
+                "stateMachineArn": "${BearerTokenRetrievalStateMachine.Arn}:live"
               }
         responses:
           default:

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -34,6 +34,24 @@ Parameters:
     Description: Link to the OTG support manual
     Type: String
     Default: "https://team-manual.account.gov.uk/teams/CRI-Orange-team/supporting-cri-orange/hmrc-otg-runbook/"
+  LambdaDeploymentPreference:
+    Description: "Specifies the configuration to enable gradual Lambda deployments"
+    Type: String
+    Default: "AllAtOnce"
+    AllowedValues:
+      - AllAtOnce
+      - Canary10Percent5Minutes
+      - Canary10Percent10Minutes
+      - Canary10Percent15Minutes
+      - Canary10Percent30Minutes
+  StepFunctionsDeploymentPreference:
+    Description: "Specifies the configuration to enable gradual StepFunction deployments"
+    Type: String
+    Default: "ALL_AT_ONCE"
+    AllowedValues:
+      - ALL_AT_ONCE
+      - CANARY
+      - LINEAR
 
 Conditions:
   EnforceCodeSigning: !Not [!Equals [!Ref CodeSigningConfigArn, ""]]
@@ -47,6 +65,9 @@ Conditions:
   IsNotDevLikeEnvironment: !Not [!Condition IsDevLikeEnvironment]
   IsNotProdEnvironment: !Not [!Condition IsProdEnvironment]
   DeployAlarms: !Or [!Condition IsProdEnvironment, !Equals [!Ref DeployAlarmsInDev, true]]
+  UseDeploymentAlarms: !Or
+    - !Not [ !Equals [ !Ref StepFunctionsDeploymentPreference, ALL_AT_ONCE ]]
+    - !Not [ !Equals [ !Ref LambdaDeploymentPreference, AllAtOnce ]]
 
 Mappings:
   Dynatrace:
@@ -104,6 +125,7 @@ Globals:
       - !Sub
         - "{{resolve:secretsmanager:${SecretArn}:SecretString:NODEJS_LAYER}}"
         - SecretArn: !FindInMap [Dynatrace, SecretArn, !Ref Environment]
+    AutoPublishAlias: live
     Environment:
       Variables:
         NODE_OPTIONS: --enable-source-maps
@@ -1156,7 +1178,6 @@ Resources:
       DefinitionUri: ../step-functions/bearer-token-retrieval.asl.json
       PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue]
       DefinitionSubstitutions:
-        SecretsManagerHandlerFunctionArn: !GetAtt SecretsManagerHandlerFunction.Arn
         StackName: !Ref AWS::StackName
       Logging:
         Destinations:
@@ -1164,9 +1185,18 @@ Resources:
               LogGroupArn: !GetAtt BearerTokenRetrievalStateMachineLogGroup.Arn
         IncludeExecutionData: True
         Level: ALL
+      AutoPublishAlias: live
+      DeploymentPreference:
+        Type: !Ref StepFunctionsDeploymentPreference
+        Interval: 10
+        Percentage: 10
+        Alarms: !If
+          - UseDeploymentAlarms
+          - - !Ref BearerTokenRetrievalStateMachineExecutionFailedCanaryAlarm
+            - !Ref BearerTokenRetrievalStateMachineTaskFailedCanaryAlarm
+          - !Ref AWS::NoValue
+        StateMachineVersionArn: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${BearerTokenRetrievalStateMachine}:live"
       Policies:
-        - LambdaInvokePolicy:
-            FunctionName: !Ref SecretsManagerHandlerFunction
         - Statement:
             - Effect: Allow
               Action: secretsmanager:GetSecretValue
@@ -1190,14 +1220,14 @@ Resources:
       LogGroupName: !Ref RedactedBearerTokenRetrievalStateMachineLogGroup
       DestinationArn: !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
 
-  BearerTokenRetrievalStateMachineFailedMetric:
+  BearerTokenRetrievalStateMachineTaskFailedMetric:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref BearerTokenRetrievalStateMachineLogGroup
-      FilterPattern: '{($.type = "ExecutionFailed")}'
+      FilterPattern: '{$.type = "TaskFailed"}'
       MetricTransformations:
         - MetricValue: "1"
-          MetricName: "BearerTokenRetrievalStateMachine-Error"
+          MetricName: "BearerTokenRetrievalStateMachineTaskFailed"
           MetricNamespace: !Sub "${AWS::StackName}/LogMessages"
 
   BearerTokenRetrievalStateMachineAlarm:
@@ -1223,6 +1253,47 @@ Resources:
       Dimensions:
         - Name: StateMachineArn
           Value: !Ref BearerTokenRetrievalStateMachine
+
+  BearerTokenRetrievalStateMachineExecutionFailedCanaryAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmName: !Sub ${AWS::StackName}-${Environment}-BearerTokenRetrieval-ExecutionFailedCanaryAlarm
+      AlarmDescription: !Sub "ExecutionFailed error returned from the BearerTokenRetrievalStateMachine"
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 1
+      MetricName: ExecutionsFailed
+      Namespace: AWS/States
+      Period: 60
+      Statistic: Sum
+      Threshold: 0
+      TreatMissingData: notBreaching
+      Dimensions:
+        - Name: StateMachineArn
+          Value: !Ref BearerTokenRetrievalStateMachine
+
+  BearerTokenRetrievalStateMachineTaskFailedCanaryAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmName: !Sub ${AWS::StackName}-${Environment}-BearerTokenRetrieval-TaskFailedCanaryAlarm
+      AlarmDescription: !Sub "TaskFailed error returned from the BearerTokenRetrievalStateMachine"
+      MetricName: "BearerTokenRetrievalStateMachineTaskFailed"
+      Namespace: !Sub ${AWS::StackName}/LogMessages
+      Statistic: Sum
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
 
   ExecuteStateMachineRole:
     Type: AWS::IAM::Role
@@ -1280,7 +1351,6 @@ Resources:
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       InsufficientDataActions: []
-      Dimensions: []
       EvaluationPeriods: 5
       DatapointsToAlarm: 2
       Threshold: 1
@@ -1332,7 +1402,6 @@ Resources:
         - !ImportValue platform-alarm-pagerduty-alert-topic
         - !ImportValue platform-alarm-critical-alert-topic
       InsufficientDataActions: []
-      Dimensions: []
       EvaluationPeriods: 5
       DatapointsToAlarm: 2
       Threshold: 80
@@ -1382,7 +1451,6 @@ Resources:
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       InsufficientDataActions: []
-      Dimensions: []
       EvaluationPeriods: 5
       DatapointsToAlarm: 2
       Threshold: 1
@@ -1446,7 +1514,6 @@ Resources:
         - !ImportValue platform-alarm-pagerduty-alert-topic
         - !ImportValue platform-alarm-critical-alert-topic
       InsufficientDataActions: []
-      Dimensions: []
       EvaluationPeriods: 5
       DatapointsToAlarm: 2
       Threshold: 80
@@ -1509,7 +1576,6 @@ Resources:
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       InsufficientDataActions: []
-      Dimensions: []
       EvaluationPeriods: 5
       DatapointsToAlarm: 2
       Threshold: 1
@@ -1559,7 +1625,6 @@ Resources:
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       InsufficientDataActions: []
-      Dimensions: []
       EvaluationPeriods: 5
       DatapointsToAlarm: 2
       Threshold: 1
@@ -1622,7 +1687,6 @@ Resources:
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
       InsufficientDataActions: []
-      Dimensions: []
       EvaluationPeriods: 5
       DatapointsToAlarm: 2
       Threshold: 2500
@@ -1678,6 +1742,14 @@ Resources:
       LoggingConfig:
         LogGroup: !Sub /aws/lambda/${AWS::StackName}/LogRedactionFunction
       CodeSigningConfigArn: !If [EnforceCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
+      DeploymentPreference:
+        Type: !Ref LambdaDeploymentPreference
+        Alarms: !If
+          - UseDeploymentAlarms
+          - [!Ref LogRedactionFunctionCanaryErrorAlarm, !Ref LogRedactionFunctionFatalErrorAlarm]
+          - [!Ref AWS::NoValue]
+        Role: !GetAtt CodeDeployServiceRole.Arn
+
       Policies:
         - Statement:
             Effect: Allow
@@ -1720,7 +1792,6 @@ Resources:
       MetricName: LogRedactionFunction-Error
       Namespace: !Sub ${AWS::StackName}/LogMessages
       Statistic: Sum
-      Dimensions: []
       Period: 120
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
@@ -1741,7 +1812,6 @@ Resources:
   LogRedactionFunctionFatalErrorAlarm:
     DependsOn: LogRedactionFunctionFatalErrorMetricFilter
     Type: AWS::CloudWatch::Alarm
-    Condition: DeployAlarms
     Properties:
       AlarmName: !Sub ${AWS::StackName}-${Environment}-LogRedactionFunction-FatalErrorAlarm
       AlarmDescription: !Sub Trigger an alarm when Fatal Error occurs. ${SupportManualURL}
@@ -1786,6 +1856,33 @@ Resources:
       DatapointsToAlarm: 1
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
+
+  LogRedactionFunctionCanaryErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "Error returned from the LogRedactionFunction Lambda."
+      AlarmName: !Sub ${AWS::StackName}-${Environment}-LogRedactionFunction-CanaryError
+      MetricName: Errors
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${AWS::StackName}-LogRedactionFunction:live"
+        - Name: FunctionName
+          Value: !Ref LogRedactionFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt LogRedactionFunction.Version.Version
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
 
   ###################################
   # Log Groups for Splunk (Redacted) #
@@ -1879,6 +1976,22 @@ Resources:
       DestinationArn: !GetAtt LogRedactionFunction.Arn
       FilterPattern: ""
       LogGroupName: !Ref PrivateOTGApiAccessLogGroup
+
+  CodeDeployServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - codedeploy.amazonaws.com
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda
+      PermissionsBoundary: !If [ UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue ]
 
 Outputs:
   PrivateApiGatewayId:

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1259,18 +1259,18 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       AlarmName: !Sub ${AWS::StackName}-${Environment}-BearerTokenRetrieval-ExecutionFailedCanaryAlarm
       AlarmDescription: !Sub "ExecutionFailed error returned from the BearerTokenRetrievalStateMachine"
-      ComparisonOperator: GreaterThanThreshold
+      ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
       MetricName: ExecutionsFailed
       Namespace: AWS/States
       Period: 60
       Statistic: Sum
-      Threshold: 0
+      Threshold: 1
       TreatMissingData: notBreaching
       Dimensions:
         - Name: StateMachineArn
@@ -1281,9 +1281,9 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       AlarmName: !Sub ${AWS::StackName}-${Environment}-BearerTokenRetrieval-TaskFailedCanaryAlarm
       AlarmDescription: !Sub "TaskFailed error returned from the BearerTokenRetrievalStateMachine"
       MetricName: "BearerTokenRetrievalStateMachineTaskFailed"
@@ -1862,9 +1862,9 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !If [IsProdEnvironment, !ImportValue platform-alarm-warning-alert-topic, !Ref AWS::NoValue]
       AlarmDescription: !Sub "Error returned from the LogRedactionFunction Lambda."
       AlarmName: !Sub ${AWS::StackName}-${Environment}-LogRedactionFunction-CanaryError
       MetricName: Errors


### PR DESCRIPTION
### What changed

Files changed:

[infrastructure/private-api.yaml](https://github.com/govuk-one-login/ipv-cri-otg-hmrc/compare/IPS-1094/step-function-canaries?expand=1#diff-c98afc506962a43221fbfdc3d8330748f4ca867565692a1d497aa8cd39f72dc0)
- Edited api spec to point to live alias of state machine

[infrastructure/template.yaml](https://github.com/govuk-one-login/ipv-cri-otg-hmrc/compare/IPS-1094/step-function-canaries?expand=1#diff-1d6a0a19507d7cdddd8ff209f817d2d18f3fb22ceec6b0eb332b0a14292c69b0)
- Added `LambdaDeploymentPreference` and `StepFunctionsDeploymentPreference` parameters
- Add deployment preference to `BearerTokenRetrievalStateMachine` and `LogRedactionFunction`
- Removed references to `SecretsManagerHandlerFunction` from `BearerTokenRetrievalStateMachine`
- Added `CodeDeployServiceRole` for canaries

Changes to alarms:
- `BearerTokenRetrievalStateMachine`:
  - Updated MetricFilter (previously not in use) to search for `TaskFailed`
  - Added `ExecutionFailed` canary alarm
- `LogRedactionFunction`:
  - Created lambda error canary alarm
  - Removed `DeployAlarms` condition from `FatalErrorAlarm` so it can be used for canaries

### Why did it change

- Canary deployments across identity pod

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-1094](https://govukverify.atlassian.net/browse/IPS-1094)

## Checklists

### Testing evidence
#### LogRedactionFunction
##### Canary deployment in progress
<img width="500" alt="LogRedactionFunctionCanary" src="https://github.com/user-attachments/assets/c84be903-b8bc-4821-964c-a69b1616601e">

##### Canary deployment complete
<img width="500" alt="LogRedactionFunctionCanaryFinished" src="https://github.com/user-attachments/assets/138fe85a-6180-479d-8845-5a6d73a47f24">

##### Canary deployment rollback
<img width="500" alt="LogRedactionFunctionCanaryRollback" src="https://github.com/user-attachments/assets/5f679a12-51ad-4f30-b9b3-956295a0d8fa">


#### BearerTokenRetrievalStepFunction

#### Canary deployment in progress
![image](https://github.com/user-attachments/assets/33845a41-d680-4fe0-9204-111255bfee7c)

#### Test rollback with API call to state machine (Based on TaskFailed, or any invalid tokenType)
<img width="500" alt="Screenshot 2024-09-27 at 16 01 32" src="https://github.com/user-attachments/assets/593db59b-6d70-4b0c-a50a-fd139c716cf7">

#### Task failed metric filter and alarm
<img width="500" alt="Screenshot 2024-09-27 at 16 10 25" src="https://github.com/user-attachments/assets/c1b2809e-37d3-4c9a-8f2b-2e20ebef0217">

#### Rollback of StepFunction to original version
<img width="500" alt="Screenshot 2024-09-27 at 16 03 32" src="https://github.com/user-attachments/assets/0aeefcf9-bae6-46ed-be80-380f341ad058">
<img width="500" alt="Screenshot 2024-09-27 at 16 06 18" src="https://github.com/user-attachments/assets/5f8a3dbb-43e5-49d5-bb71-0f44110bc039">

#### Next canary deployment (successful API call and execution)
<img width="500" alt="Screenshot 2024-09-27 at 16 15 49" src="https://github.com/user-attachments/assets/d675d53a-da22-45f7-8ff1-d0bd921644bf">
<img width="500" alt="image" src="https://github.com/user-attachments/assets/47c19a21-99e9-41ec-8e73-d33741e8d3be">


### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-1094]: https://govukverify.atlassian.net/browse/IPS-1094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ