### PR TITLE
IPS-1155: Set alarms to true

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1258,7 +1258,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Condition: UseCanaryDeploymentAlarms
     Properties:
-      ActionsEnabled: false
+      ActionsEnabled: true
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
@@ -1281,7 +1281,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Condition: UseCanaryDeploymentAlarms
     Properties:
-      ActionsEnabled: false
+      ActionsEnabled: true
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
@@ -1748,7 +1748,7 @@ Resources:
         Type: !Ref LambdaDeploymentPreference
         Alarms: !If
           - UseCanaryDeploymentAlarms
-          - [!Ref LogRedactionFunctionErrorCanaryAlarm, !Ref LogRedactionFunctionFatalErrorAlarm]
+          - [!Ref LogRedactionFunctionCanaryErrorAlarm, !Ref LogRedactionFunctionFatalErrorAlarm]
           - [!Ref AWS::NoValue]
         Role: !GetAtt CodeDeployServiceRole.Arn
 
@@ -1859,17 +1859,17 @@ Resources:
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
 
-  LogRedactionFunctionErrorCanaryAlarm:
+  LogRedactionFunctionCanaryErrorAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: UseCanaryDeploymentAlarms
     Properties:
-      ActionsEnabled: false
+      ActionsEnabled: true
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmDescription: !Sub "Error returned from the LogRedactionFunction Lambda."
-      AlarmName: !Sub ${AWS::StackName}-${Environment}-LogRedactionFunction-CanaryError
+      AlarmName: !Sub ${AWS::StackName}-${Environment}-LogRedactionFunction-CanaryErrorAlarm
       MetricName: Errors
       Dimensions:
         - Name: Resource


### PR DESCRIPTION
### What changed

- Set alarm actions to true

### Why did it change

- This step should be done after the initial alarm deployment to reduce spamming the slack channels 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-1155](https://govukverify.atlassian.net/browse/IPS-1155)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[IPS-1155]: https://govukverify.atlassian.net/browse/IPS-1155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ