### PR TITLE
OJ-2800: set refresh token retries zero

### DIFF
--- a/integration-tests/tests/mocked/oauth-token-generator/oauth-token-asl-types.ts
+++ b/integration-tests/tests/mocked/oauth-token-generator/oauth-token-asl-types.ts
@@ -1,0 +1,15 @@
+export interface ParallelState {
+  Retry: [
+    {
+      ErrorEquals: string[];
+      BackoffRate: number;
+      MaxAttempts: number;
+      IntervalSeconds: number;
+    },
+  ];
+}
+export interface StateMachineDefinition {
+  States: {
+    [stateName: string]: ParallelState;
+  };
+}


### PR DESCRIPTION
## Proposed changes

Disable the parallel loop retries on the entire step function while testing retries on failing HMRC bearer token handler that uncoverable and leads to a failed state

### Why did it change

Parallel loop retries where the reason for the test not passing as it enters an unrecoverable loop on parallel state failures on step function local. The scope of this test does not require retrying the entire step function so retries of been disabled retries on the `Refresh Token` parallel state by setting it `MaxAttempts` to zero i.e.

```
      "Retry": [
        {
          "ErrorEquals": [
            "States.ALL"
          ],
          "BackoffRate": 2,
          "MaxAttempts": 3,
          "IntervalSeconds": 20
        }
      ]
```
to

```
      "Retry": [
        {
          "ErrorEquals": [
            "States.ALL"
          ],
          "BackoffRate": 2,
          "MaxAttempts": 0,
          "IntervalSeconds": 20
        }
      ]
```

### Issue tracking

- [OJ-2800](https://govukverify.atlassian.net/browse/OJ-2800)



[OJ-2800]: https://govukverify.atlassian.net/browse/OJ-2800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ