### PR TITLE
OJ-2887: Use role instead of function arn

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -648,7 +648,7 @@ Resources:
             Principal:
               AWS: [
                 !GetAtt LogRedactionFunctionRole.Arn,
-                !GetAtt BearerTokenHandlerFunction.Arn
+                !GetAtt BearerTokenHandlerFunctionRole.Arn
               ]
             Action:
             - "kms:Encrypt*"


### PR DESCRIPTION
## Proposed changes

### Why did it change
Deployment fails as it cannot use the ARN and must reference the role. 
