### PR TITLE
OJ-2887: Allow BearerTokenHandlerFunctionRole access to TOTP Secret

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -842,12 +842,6 @@ Resources:
             Action: "secretsmanager:*"
             Principal:
               AWS: !Sub "arn:aws:iam::${AWS::AccountId}:role/PL-otg-hmrc-service-pl-DeployRole-0a8d7d508bb6"
-          - Sid: AllowStateMachine
-            Effect: "Allow"
-            Resource: !Ref TOTPSecretProduction
-            Action: "secretsmanager:*"
-            Principal:
-              AWS: !GetAtt OAuthTokenStateMachineRole.Arn
           - Sid: AllowBearerTokenHandlerFunction
             Effect: "Allow"
             Resource: !Ref TOTPSecretProduction

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -848,6 +848,12 @@ Resources:
             Action: "secretsmanager:*"
             Principal:
               AWS: !GetAtt OAuthTokenStateMachineRole.Arn
+          - Sid: AllowBearerTokenHandlerFunction
+            Effect: "Allow"
+            Resource: !Ref TOTPSecretProduction
+            Action: "secretsmanager:*"
+            Principal:
+              AWS: !GetAtt BearerTokenHandlerFunctionRole.Arn
           - Sid: ElevatedAdminAccess
             Effect: Allow
             Resource: !Ref TOTPSecretProduction

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -864,7 +864,7 @@ Resources:
               StringNotLike:
                 "aws:PrincipalArn":
                   - !Sub "arn:aws:iam::${AWS::AccountId}:role/PL-otg-hmrc-service-pl-DeployRole-0a8d7d508bb6"
-                  - !GetAtt OAuthTokenStateMachineRole.Arn
+                  - !GetAtt BearerTokenHandlerFunctionRole.Arn
                   - !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/eu-west-2/AWSReservedSSO_di-ipv-cri-otg-hmrc-prod-adm-kms_c1de3f0ff8700ff0"
 
   DenySecretsIAMPolicy:


### PR DESCRIPTION
## Proposed changes

### Why did it change
To give our Lambda access to the TOTP Secret as the responsibility was moved away from the state machine.

### Issue tracking
- [OJ-2887](https://govukverify.atlassian.net/browse/OJ-2887)

[OJ-2887]: https://govukverify.atlassian.net/browse/OJ-2887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ