### PR TITLE
BAU: Fix deployment issues caused by log group conflicts

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -66,8 +66,8 @@ Conditions:
   IsNotProdEnvironment: !Not [!Condition IsProdEnvironment]
   DeployAlarms: !Or [!Condition IsProdEnvironment, !Equals [!Ref DeployAlarmsInDev, true]]
   UseCanaryDeploymentAlarms: !Or
-    - !Not [ !Equals [ !Ref StepFunctionsDeploymentPreference, ALL_AT_ONCE ]]
-    - !Not [ !Equals [ !Ref LambdaDeploymentPreference, AllAtOnce ]]
+    - !Not [!Equals [!Ref StepFunctionsDeploymentPreference, ALL_AT_ONCE]]
+    - !Not [!Equals [!Ref LambdaDeploymentPreference, AllAtOnce]]
 
 Mappings:
   Dynatrace:
@@ -506,7 +506,7 @@ Resources:
     Properties:
       Handler: lambdas/bearer-token-handler/src/bearer-token-handler.lambdaHandler
       LoggingConfig:
-        LogGroup: !Sub /aws/lambda/${AWS::StackName}/BearerTokenHandlerFunction
+        LogGroup: !Ref BearerTokenHandlerFunctionLogGroup
       CodeSigningConfigArn: !If [EnforceCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
       Policies:
         - AWSSecretsManagerGetSecretValuePolicy:
@@ -1534,7 +1534,7 @@ Resources:
     Properties:
       FunctionName: !GetAtt LogRedactionFunction.Arn
       Action: lambda:InvokeFunction
-      Principal: !Join [ ".", [ "logs", !Ref "AWS::Region", "amazonaws.com" ] ]
+      Principal: !Join [".", ["logs", !Ref "AWS::Region", "amazonaws.com"]]
       SourceAccount: !Ref AWS::AccountId
 
   LogRedactionFunction:
@@ -1546,7 +1546,7 @@ Resources:
     Properties:
       Handler: lambdas/log-redaction/src/redact-handler.lambdaHandler
       LoggingConfig:
-        LogGroup: !Sub /aws/lambda/${AWS::StackName}/LogRedactionFunction
+        LogGroup: !Ref LogRedactionFunctionLogGroup
       CodeSigningConfigArn: !If [EnforceCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
       DeploymentPreference:
         Type: !Ref LambdaDeploymentPreference
@@ -1768,7 +1768,7 @@ Resources:
                 - codedeploy.amazonaws.com
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda
-      PermissionsBoundary: !If [ UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue ]
+      PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue]
 
 Outputs:
   PrivateApiGatewayId:

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -688,7 +688,7 @@ Resources:
               StringNotLike:
                 "aws:PrincipalArn":
                   - !Sub "arn:aws:iam::${AWS::AccountId}:role/PL-otg-hmrc-service-pl-DeployRole-0a8d7d508bb6"
-                  - !GetAtt BearerTokenHandlerFunction.Arn
+                  - !GetAtt BearerTokenHandlerFunctionRole.Arn
                   - !GetAtt LogRedactionFunctionRole.Arn
                   - !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/eu-west-2/AWSReservedSSO_di-ipv-cri-otg-hmrc-prod-adm-kms_c1de3f0ff8700ff0"
               ArnNotLike:


### PR DESCRIPTION
The lambda resources need to depend on the corresponding log group resources to ensure that the lambda service doesn't attempt to create a duplicate log group and cause an error during deployment. Creating the dependency ensures that the log group gets created before the lambda and there is no conflict.