### PR TITLE
IPS-665-remove-policy

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -867,24 +867,6 @@ Resources:
                   - !GetAtt BearerTokenHandlerFunctionRole.Arn
                   - !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/eu-west-2/AWSReservedSSO_di-ipv-cri-otg-hmrc-prod-adm-kms_c1de3f0ff8700ff0"
 
-  DenySecretsIAMPolicy:
-    Condition: IsProdEnvironment
-    Type: AWS::IAM::ManagedPolicy
-    Properties:
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Deny
-            Action:
-              - "states:GetExecutionHistory"
-            Resource:
-              - !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:execution:${AWS::StackName}-OAuthTokenGenerator*
-          - Effect: Deny
-            Action:
-              - "logs:*"
-            Resource:
-              - !GetAtt OAuthTokenStateMachineLogGroup.Arn
-
   OAuthTokenStateMachine:
     Type: AWS::Serverless::StateMachine
     Properties:


### PR DESCRIPTION
### What changed

- Removed `DenySecretsIAMPolicy`

### Why did it change

- No longer needed as not feasible to add to all groups/permission sets, as originally discussed
- See full thread on https://govukverify.atlassian.net/browse/PSREGOV-1242 for context

The secret and key remain inaccessible to everyone except members of the `di-ipv-cri-otg-hmrc-prod-adm-kms` group

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-665](https://govukverify.atlassian.net/browse/IPS-665)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-665]: https://govukverify.atlassian.net/browse/IPS-665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ