### PR TITLE
OJ-2897: Only redact step function logs

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -460,7 +460,7 @@ Resources:
     Condition: IsNotDevLikeEnvironment
     Properties:
       FilterPattern: ""
-      LogGroupName: !Ref RedactedPrivateOTGApiAccessLogGroup
+      LogGroupName: !Ref PrivateOTGApiAccessLogGroup
       DestinationArn: !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
 
   PrivateOTGApiFatalErrorMetricFilter:
@@ -527,7 +527,7 @@ Resources:
     Condition: IsNotDevLikeEnvironment
     Properties:
       FilterPattern: ""
-      LogGroupName: !Ref RedactedBearerTokenHandlerFunctionLogGroup
+      LogGroupName: !Ref BearerTokenHandlerFunctionLogGroup
       DestinationArn: !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
 
   # BearerTokenHandlerFunction Alarms
@@ -1676,20 +1676,6 @@ Resources:
   ###################################
   # Log Groups for Splunk (Redacted) #
   ###################################
-  RedactedBearerTokenHandlerFunctionLogGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      LogGroupName: !Sub /aws/lambda/${AWS::StackName}/BearerTokenHandlerFunction-redacted
-      RetentionInDays: 30
-
-  BearerTokenHandlerFunctionLogsSubscriptionFilter:
-    Type: AWS::Logs::SubscriptionFilter
-    DependsOn: LogRedactionFunctionCloudWatchPermissions
-    Properties:
-      FilterName: "Redaction"
-      DestinationArn: !GetAtt LogRedactionFunction.Arn
-      FilterPattern: ""
-      LogGroupName: !Ref BearerTokenHandlerFunctionLogGroup
 
   RedactedOAuthTokenStateMachineLogGroup:
     Type: AWS::Logs::LogGroup
@@ -1720,21 +1706,6 @@ Resources:
       DestinationArn: !GetAtt LogRedactionFunction.Arn
       FilterPattern: ""
       LogGroupName: !Ref BearerTokenRetrievalStateMachineLogGroup
-
-  RedactedPrivateOTGApiAccessLogGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      LogGroupName: !Sub /aws/vendedlogs/apigateway/${AWS::StackName}-${PrivateOTGApi}-private-AccessLogs-redacted
-      RetentionInDays: 30
-
-  PrivateOTGApiAccessLogGroupSubscriptionFilter:
-    Type: AWS::Logs::SubscriptionFilter
-    DependsOn: LogRedactionFunctionCloudWatchPermissions
-    Properties:
-      FilterName: "Redaction"
-      DestinationArn: !GetAtt LogRedactionFunction.Arn
-      FilterPattern: ""
-      LogGroupName: !Ref PrivateOTGApiAccessLogGroup
 
   CodeDeployServiceRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Remove redaction of lambda and API log groups
- Push unredacted log groups to splunk

### Why did it change

Because these are logs we have control over we do not need to redact them, we should just not be logging sensitive information. The redaction is only completely necessary for step functions where we can't control the log output.

This should reduce the amount of logs that are having to be processed and pushed to cloudwatch and help us avoid rate limit issues

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2897](https://govukverify.atlassian.net/browse/OJ-2897)



[OJ-2897]: https://govukverify.atlassian.net/browse/OJ-2897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ