### PR TITLE
OJ-2897: Rename RedactionLogStreamTrackingTable TableName

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -151,7 +151,7 @@ Resources:
   RedactionLogStreamTrackingTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: !Sub ${AWS::StackName}-logstream-tracking-tbl
+      TableName: !Sub ${AWS::StackName}-redact-logstream-tracking
       BillingMode: PAY_PER_REQUEST
       AttributeDefinitions:
         - AttributeName: logStreamName


### PR DESCRIPTION
## Proposed changes

### Why did it change
Renamed the TableName for RedactionLogStreamTrackingTable as it failed to create in the higher environments due to name already being used. 

### Issue tracking
- [OJ-2897](https://govukverify.atlassian.net/browse/OJ-2897)


[OJ-2897]: https://govukverify.atlassian.net/browse/OJ-2897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ