### PR TITLE
BAU: Minor refactor to BearerTokenRetrievalStateMachineAlarm

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1043,14 +1043,14 @@ Resources:
       AlarmDescription: !Sub Bearer Token failed 4 or more requests in the last hour. ${SupportManualURL}
       AlarmName: !Sub ${AWS::StackName}-${Environment}-BearerTokenRetrievalStateMachineAlarm
       ComparisonOperator: GreaterThanThreshold
-      DatapointsToAlarm: 4
-      EvaluationPeriods: 12
+      DatapointsToAlarm: 1
+      EvaluationPeriods: 1
       MetricName: ExecutionsFailed
       Namespace: AWS/States
-      Period: 300
+      Period: 3600
       Statistic: Sum
-      Threshold: 0
-      TreatMissingData: missing
+      Threshold: 3
+      TreatMissingData: notBreaching
       Dimensions:
         - Name: StateMachineArn
           Value: !Ref BearerTokenRetrievalStateMachine


### PR DESCRIPTION
## Proposed changes

### What changed

Refactored BearerTokenRetrievalStateMachineAlarm to treatMissingData as notBreaching.
Refactored BearerTokenRetrievalStateMachineAlarm to make the alarm match the description.

### Why did it change

The alarm transitions to OK every morning due to MissingData being treated as missing. The alarm triggers a slack message causing the channel to get spammed.

Also, previously the alarm did not match the description, rather than 4 failures within an hour, it was atleast 1 failure in 4 different 5 minute periods within an hour. This would mean if for example, if 100 executions failed but only within a 5 minute period it would not trigger the alarm.

### Similar PR for check-hmrc-api
https://github.com/govuk-one-login/ipv-cri-check-hmrc-api/pull/521

### Issue 

Note: See alarm threshold is ExecutionsFailed > 0 for 4 datapoints within 1 hour, to match the description (... failed 4 or more requests in the last hour.) we want this to be ExecutionsFailed > 3 for 1 datapoints within 1 hour (which this PR will do)
![image](https://github.com/user-attachments/assets/5f1a148c-cad2-494f-97bc-792ae035d96f)
<img width="684" alt="image" src="https://github.com/user-attachments/assets/e9d6e5b3-0ce1-402e-930c-14c16c5f945b">

