### PR TITLE
IPS-1289 allowed values for lambda deployment preference removed

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -38,12 +38,6 @@ Parameters:
     Description: "Specifies the configuration to enable gradual Lambda deployments"
     Type: String
     Default: "AllAtOnce"
-    AllowedValues:
-      - AllAtOnce
-      - Canary10Percent5Minutes
-      - Canary10Percent10Minutes
-      - Canary10Percent15Minutes
-      - Canary10Percent30Minutes
   StepFunctionsDeploymentPreference:
     Description: "Specifies the configuration to enable gradual StepFunction deployments"
     Type: String


### PR DESCRIPTION

## Proposed changes

### What changed

Allowed values for lambda deployment preference removed to allow any values.

### Why did it change

This change was required to allow any values to be passed in the pipeline parameter. I was going to add the allowed value of LambdaCanary50Percent5Minutes as that is what is set in the pipeline but we may want to make changes in the future so this will remove the need to update this template again when pipeline parameter changes.

This will be in line with address and kbv as they dont specify allowed values.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-1289](https://govukverify.atlassian.net/browse/IPS-1289)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-1289]: https://govukverify.atlassian.net/browse/IPS-1289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ