### PR TITLE
IPS-1213: Point subscription filter to alias

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1706,10 +1706,10 @@ Resources:
 
   OAuthTokenStateMachineLogsSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
-    DependsOn: LogRedactionFunctionCloudWatchPermissions
+    DependsOn: LogRedactionFunctionCloudWatchAliasPermissions
     Properties:
       FilterName: "Redaction"
-      DestinationArn: !GetAtt LogRedactionFunction.Arn
+      DestinationArn: !Ref LogRedactionFunction.Alias
       FilterPattern: ""
       LogGroupName: !Ref OAuthTokenStateMachineLogGroup
 
@@ -1721,10 +1721,10 @@ Resources:
 
   BearerTokenRetrievalStateMachineSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
-    DependsOn: LogRedactionFunctionCloudWatchPermissions
+    DependsOn: LogRedactionFunctionCloudWatchAliasPermissions
     Properties:
       FilterName: "Redaction"
-      DestinationArn: !GetAtt LogRedactionFunction.Arn
+      DestinationArn: !Ref LogRedactionFunction.Alias
       FilterPattern: ""
       LogGroupName: !Ref BearerTokenRetrievalStateMachineLogGroup
 


### PR DESCRIPTION
### What changed

- Point subscription filter of the state machine log groups to the lambda alias
- Permissions updated here: https://github.com/govuk-one-login/ipv-cri-otg-hmrc/compare/IPS-1213-perms-only?expand=1
- Follow on from initial canary PR here: https://github.com/govuk-one-login/ipv-cri-otg-hmrc/pull/92

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/f36dc686-c581-4cb1-8b5c-6467988d73fc" />


### Why did it change

- See above

### Screenshots

#### Manually triggering state machine

<img width="500" alt="Screenshot 2025-01-08 at 17 30 41" src="https://github.com/user-attachments/assets/d24de69a-a25c-4fa3-831c-155d7d8758a7" />

#### Standard log stream created
<img width="500" alt="Screenshot 2025-01-08 at 17 30 50" src="https://github.com/user-attachments/assets/e45bb845-01df-4d9b-a993-e5e78d40fe42" />

#### Redacted log stream created
<img width="500" alt="Screenshot 2025-01-08 at 17 31 50" src="https://github.com/user-attachments/assets/499c63ef-62d2-4349-8dcf-3f6d1eae473f" />



### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-1213](https://govukverify.atlassian.net/browse/IPS-1213)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-1213]: https://govukverify.atlassian.net/browse/IPS-1213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ