### PR TITLE
IPS-1213: Add alias permissions for cloudwatch

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1528,6 +1528,14 @@ Resources:
       Principal: !Join [".", ["logs", !Ref "AWS::Region", "amazonaws.com"]]
       SourceAccount: !Ref AWS::AccountId
 
+  LogRedactionFunctionCloudWatchAliasPermissions:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref LogRedactionFunction.Alias
+      Action: lambda:InvokeFunction
+      Principal: !Join [".", ["logs", !Ref "AWS::Region", "amazonaws.com"]]
+      SourceAccount: !Ref AWS::AccountId
+
   LogRedactionFunction:
     Type: AWS::Serverless::Function
     Metadata:
@@ -1672,7 +1680,7 @@ Resources:
       MetricName: Errors
       Dimensions:
         - Name: Resource
-          Value: !Sub "${AWS::StackName}-LogRedactionFunction:live"
+          Value: !Sub ${LogRedactionFunction}:live
         - Name: FunctionName
           Value: !Ref LogRedactionFunction
         - Name: ExecutedVersion


### PR DESCRIPTION
### What changed

- Add cloudwatch permissions for alias
- Update alarm

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/51dd4025-7d53-4072-ade4-693e2dbb1382" />


### Why did it change

- Needed for the next PR, where the Subscription Filter DestinationArn is updated: https://github.com/govuk-one-login/ipv-cri-otg-hmrc/pull/187/files

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-1213](https://govukverify.atlassian.net/browse/IPS-1213)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-1213]: https://govukverify.atlassian.net/browse/IPS-1213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ