### PR TITLE
OJ-3048: Update sonar action

### DIFF
--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run SonarCloud scan
-        uses: govuk-one-login/github-actions/code-quality/sonarcloud@0eb1972f8c0d539b3ff4c24d78b3dba917343e7c
+        uses: govuk-one-login/github-actions/code-quality/sonarcloud@5480cced560e896dea12c47ea33e548a4d093e65
         with:
           coverage-artifact: ${{ needs.unit-tests.outputs.coverage-artifact }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Proposed changes

### What changed

Update sonar GHA to the latest commit SHA.

### Why did it change

Upstream sonar action is being deprecated.

### Issue tracking

- [OJ-3048](https://govukverify.atlassian.net/browse/OJ-3048)


[OJ-3048]: https://govukverify.atlassian.net/browse/OJ-3048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ