### PR TITLE
OJ-3096: upgrade - update node runtime version to 22

### DIFF
--- a/.github/workflows/post-merge-deploy-to-build.yml
+++ b/.github/workflows/post-merge-deploy-to-build.yml
@@ -19,11 +19,6 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
 
-      - name: Setup SAM
-        uses: aws-actions/setup-sam@v2
-        with:
-          version: 1.113.0
-
       - name: Assume temporary AWS role
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.github/workflows/post-merge-deploy-to-dev.yml
+++ b/.github/workflows/post-merge-deploy-to-dev.yml
@@ -19,11 +19,6 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
 
-      - name: Setup SAM
-        uses: aws-actions/setup-sam@v2
-        with:
-          version: 1.113.0
-
       - name: Assume temporary AWS role
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         files: ".*\\.(js|ts)"
         pass_filenames: false
   - repo: https://github.com/aws-cloudformation/cfn-lint
-    rev: v0.85.2
+    rev: v1.27.0
     hooks:
       - id: cfn-lint
         files: .template\.ya?ml$

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -105,7 +105,7 @@ Globals:
   Function:
     Timeout: 30
     CodeUri: ..
-    Runtime: nodejs18.x
+    Runtime: nodejs22.x
     Architectures: [arm64]
     PermissionsBoundary:
       !If [UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue]


### PR DESCRIPTION

## Proposed changes

### What changed

- Upgrade node version from 18 to 22
- Remove Setup SAM step from the post merge deploy dev & build GHA.
- update pre-commit version

### Why did it change

Node 18 has reached end of active live support and SAM CLI 1.132.0+ is needed to support node 22 runtimes.

### Issue tracking

- [OJ-3096](https://govukverify.atlassian.net/browse/OJ-3096)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-3096]: https://govukverify.atlassian.net/browse/OJ-3096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ