### PR TITLE
OJ-3208: chore - update tar-fs version to fixed version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8480,9 +8480,9 @@
       }
     },
     "node_modules/dockerode/node_modules/tar-fs": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
-      "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12127,9 +12127,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
-      "integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.9.tgz",
+      "integrity": "sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION


## Proposed changes

### What changed

- Updated `tar-fs` to the versions that has been patched in 3.0.9, 2.1.3, and 1.16.5 within `package-lock.json`

### Why did it change

Security vulnerability.

### Issue tracking


- [OJ-3208](https://govukverify.atlassian.net/browse/OJ-3208)

## Checklists

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-3208]: https://govukverify.atlassian.net/browse/OJ-3208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ