### PR TITLE
OJ-3458: Fix preview stacks not getting deleted

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -891,6 +891,8 @@ Resources:
   TOTPSecretPolicySandbox:
     Condition: IsNotProdEnvironment
     Type: AWS::SecretsManager::ResourcePolicy
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       BlockPublicPolicy: false
       SecretId: !GetAtt TOTPSecretSandbox.Id
@@ -915,6 +917,8 @@ Resources:
   TOTPSecretPolicyMonitoring:
     Condition: IsNotProdOrIntegrationEnvironment
     Type: AWS::SecretsManager::ResourcePolicy
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       BlockPublicPolicy: false
       SecretId: !GetAtt TOTPSecretMonitoring.Id


### PR DESCRIPTION
## Proposed changes

### What changed
Added missing retention policy to `TOTPSecretPolicySandbox` and `TOTPSecretPolicyMonitoring`. This will allow stacks to delete while leaving the secrets in the account. 

### Issue tracking
- [OJ-3458](https://govukverify.atlassian.net/browse/OJ-3458)



[OJ-3458]: https://govukverify.atlassian.net/browse/OJ-3458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ