### PR TITLE
OJ-3458: delete secrets when stack is deleted in otg-dev

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -861,8 +861,8 @@ Resources:
   TOTPSecretSandbox:
     Type: AWS::SecretsManager::Secret
     Condition: IsNotProdEnvironment
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
+    DeletionPolicy: !If [IsDevLikeEnvironment, !Ref AWS::NoValue, Retain]
+    UpdateReplacePolicy: !If [IsDevLikeEnvironment, !Ref AWS::NoValue, Retain]
     Properties:
       Name: !Sub HMRC/TOTPSecret/${AWS::StackName}/sandbox
       KmsKeyId: !GetAtt SecretsManagerHandlerEncryptionKey.Arn
@@ -871,8 +871,8 @@ Resources:
   TOTPSecretMonitoring:
     Type: AWS::SecretsManager::Secret
     Condition: IsNotProdOrIntegrationEnvironment
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
+    DeletionPolicy: !If [ IsDevLikeEnvironment, !Ref AWS::NoValue, Retain ]
+    UpdateReplacePolicy: !If [ IsDevLikeEnvironment, !Ref AWS::NoValue, Retain ]
     Properties:
       Name: !Sub HMRC/TOTPSecret/${AWS::StackName}/monitoring
       KmsKeyId: !GetAtt SecretsManagerHandlerEncryptionKey.Arn


### PR DESCRIPTION
## Proposed changes

### What changed
Added a condition around the secrets so that they get cleaned up in dev environments. 

We have stale secrets in the OTG account because of the retain policy.

### Issue tracking
- [OJ-3458](https://govukverify.atlassian.net/browse/OJ-3458)

[OJ-3458]: https://govukverify.atlassian.net/browse/OJ-3458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ