### PR TITLE
OJ-3748: New post-merge GHA

### DIFF
--- a/.github/workflows/post-merge-deploy-to-build.yml
+++ b/.github/workflows/post-merge-deploy-to-build.yml
@@ -1,8 +1,6 @@
 name: Package for Build
 on:
-  push:
-    branches:
-      - main
+  workflow_call:
   workflow_dispatch: # Deploy Manually
 jobs:
   deploy:

--- a/.github/workflows/post-merge-deploy-to-dev.yml
+++ b/.github/workflows/post-merge-deploy-to-dev.yml
@@ -1,8 +1,6 @@
 name: Package for Dev
 on:
-  push:
-    branches:
-      - main
+  workflow_call:
   workflow_dispatch: # Deploy Manually
 jobs:
   deploy:

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -1,0 +1,28 @@
+name: Post merge
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  id-token: write
+  security-events: write
+
+jobs:
+  scan-and-unit-test:
+    name: Scan repo
+    uses: ./.github/workflows/scan-repo.yml
+    secrets: inherit
+
+  deploy-dev:
+    name: Package for dev
+    needs: scan-and-unit-test
+    uses: ./.github/workflows/post-merge-deploy-to-dev.yml
+    secrets: inherit
+
+  deploy-build:
+    name: Package for build
+    needs: scan-and-unit-test
+    uses: ./.github/workflows/post-merge-deploy-to-build.yml
+    secrets: inherit

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -3,8 +3,7 @@ name: Scan repository
 on:
   workflow_dispatch:
   pull_request:
-  push:
-    branches: [main]
+  workflow_call:
   schedule:
     # Every Monday at 9am
     - cron: "0 9 * * 1"
@@ -20,7 +19,6 @@ jobs:
     uses: ./.github/workflows/run-unit-tests.yml
     permissions:
       contents: read
-      actions: read
     with:
       coverage-report: true
 
@@ -31,7 +29,6 @@ jobs:
     if: ${{ success() || needs.coverage.result == 'skipped' }}
     permissions:
       contents: read
-      pull-requests: read
     steps:
       - name: Run SonarCloud scan
         uses: govuk-one-login/github-actions/code-quality/sonarcloud@5480cced560e896dea12c47ea33e548a4d093e65
@@ -46,7 +43,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      actions: read
       security-events: write
     steps:
       - name: Run CodeQL scan

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -116,7 +116,9 @@
     },
     {
       "path": "detect_secrets.filters.regex.should_exclude_secret",
-      "pattern": []
+      "pattern": [
+        "inherit"
+      ]
     }
   ],
   "results": {},


### PR DESCRIPTION
## Proposed changes

### What changed

Created a new `post-merge.yml `GHA. 

### Why did it change

We previously deployed even if scan-repo failed post-merge. This now makes deploying depend on scan-repo completing successfully.

### Issue tracking

- [OJ-3748](https://govukverify.atlassian.net/browse/OJ-3748)

[OJ-3748]: https://govukverify.atlassian.net/browse/OJ-3748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ